### PR TITLE
fix name error

### DIFF
--- a/packages/lending/src/types.ts
+++ b/packages/lending/src/types.ts
@@ -288,7 +288,7 @@ export type Pool = {
     /** Token decimals */
     decimals: number
     /** Token logo URI */
-    logoURI: string
+    logoUri: string
     /** Token symbol */
     symbol: string
   }


### PR DESCRIPTION
When I use the SDK to read the Pool, the result of `console.log` is as follows:

<img width="900" height="190" alt="image" src="https://github.com/user-attachments/assets/d655bf05-f7e1-4b00-9a76-aa98925062f5" />

At the same time, I tried to read it using `logoURI`, but the result was empty, so is there an error in this type definition part?