### PR TITLE
feat: 1.4.3

### DIFF
--- a/packages/lending/package.json
+++ b/packages/lending/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@naviprotocol/lending",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "NAVI Lending SDK",
   "license": "MIT",
   "keywords": [

--- a/packages/lending/src/utils.ts
+++ b/packages/lending/src/utils.ts
@@ -87,7 +87,7 @@ export function withCache<T extends (...args: any[]) => Promise<any>>(fn: T): T 
   let cache: Record<
     string,
     {
-      data: undefined
+      data: any
       cacheAt: number
     }
   > = {}
@@ -103,7 +103,9 @@ export function withCache<T extends (...args: any[]) => Promise<any>>(fn: T): T 
         typeof options?.cacheTime === 'undefined' ||
         options.cacheTime > Date.now() - cacheData.cacheAt
       ) {
-        return cacheData.data
+        // Wrap in Promise.resolve to honor the declared `Promise<any>` return type.
+        // Returning the cached value synchronously breaks `.then()` chaining at call sites.
+        return Promise.resolve(cacheData.data)
       }
     }
 

--- a/packages/lending/tests/utils.test.ts
+++ b/packages/lending/tests/utils.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { withCache } from '../src/utils'
+import type { CacheOption } from '../src/types'
+
+describe('withCache', () => {
+  it('returns a Promise on the first call (cache miss)', async () => {
+    const fn = vi.fn(async (_options?: Partial<CacheOption>) => 'hello')
+    const cached = withCache(fn)
+
+    const result = cached()
+    expect(typeof (result as any).then).toBe('function')
+    expect(await result).toBe('hello')
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns a Promise on subsequent calls (cache hit) — regression for `.then is not a function`', async () => {
+    const fn = vi.fn(async (_options?: Partial<CacheOption>) => 'hello')
+    const cached = withCache(fn)
+
+    await cached()
+    expect(fn).toHaveBeenCalledTimes(1)
+
+    const cachedResult = cached()
+    // Critical: cached path must still return a thenable so `.then()` chaining
+    // does not throw `TypeError: ... .then is not a function` at call sites.
+    expect(typeof (cachedResult as any).then).toBe('function')
+    expect(await cachedResult).toBe('hello')
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('respects disableCache option', async () => {
+    const fn = vi.fn(async (_options?: Partial<CacheOption>) => 'hello')
+    const cached = withCache(fn)
+
+    await cached()
+    await cached({ disableCache: true })
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it('respects cacheTime option (cache expired)', async () => {
+    const fn = vi.fn(async (_options?: Partial<CacheOption>) => 'hello')
+    const cached = withCache(fn)
+
+    await cached()
+    // cacheTime smaller than the elapsed time forces a refresh.
+    await new Promise((resolve) => setTimeout(resolve, 5))
+    await cached({ cacheTime: 1 })
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps cache when cacheTime is large enough', async () => {
+    const fn = vi.fn(async (_options?: Partial<CacheOption>) => 'hello')
+    const cached = withCache(fn)
+
+    await cached({ cacheTime: 60_000 })
+    await cached({ cacheTime: 60_000 })
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Description

Describe the changes or additions included in this PR.

## Test plan

How did you test the new or updated feature?

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small change to caching return behavior plus unit tests; primary impact is making cache hits consistently async, which could affect timing but fixes `.then is not a function` call-site errors.
> 
> **Overview**
> Bumps `@naviprotocol/lending` version to `1.4.3`.
> 
> Fixes `withCache` so cache hits return `Promise.resolve(cachedValue)` instead of a synchronous value, preventing `.then is not a function` errors while keeping `cacheTime`/`disableCache` behavior.
> 
> Adds Vitest coverage for `withCache` promise/thenable behavior and cache option handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a46ec386045f403738af459b571619cc1f903375. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->