### PR TITLE
feat: sui eco market

### DIFF
--- a/packages/lending/package.json
+++ b/packages/lending/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@naviprotocol/lending",
-  "version": "1.4.3",
+  "version": "1.4.4-beta.6",
   "description": "NAVI Lending SDK",
   "license": "MIT",
   "keywords": [

--- a/packages/lending/package.json
+++ b/packages/lending/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@naviprotocol/lending",
-  "version": "1.4.4-beta.7",
+  "version": "1.4.4-beta.8",
   "description": "NAVI Lending SDK",
   "license": "MIT",
   "keywords": [

--- a/packages/lending/package.json
+++ b/packages/lending/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@naviprotocol/lending",
-  "version": "1.4.4-beta.6",
+  "version": "1.4.4-beta.7",
   "description": "NAVI Lending SDK",
   "license": "MIT",
   "keywords": [

--- a/packages/lending/package.json
+++ b/packages/lending/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@naviprotocol/lending",
-  "version": "1.4.4-beta.10",
+  "version": "1.4.4",
   "description": "NAVI Lending SDK",
   "license": "MIT",
   "keywords": [

--- a/packages/lending/package.json
+++ b/packages/lending/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@naviprotocol/lending",
-  "version": "1.4.4-beta.9",
+  "version": "1.4.4-beta.10",
   "description": "NAVI Lending SDK",
   "license": "MIT",
   "keywords": [

--- a/packages/lending/package.json
+++ b/packages/lending/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@naviprotocol/lending",
-  "version": "1.4.4-beta.8",
+  "version": "1.4.4-beta.9",
   "description": "NAVI Lending SDK",
   "license": "MIT",
   "keywords": [

--- a/packages/lending/src/market.ts
+++ b/packages/lending/src/market.ts
@@ -23,6 +23,11 @@ export const MARKETS = {
     id: 1,
     key: 'ember',
     name: 'Ember Market'
+  },
+  'sui-eco': {
+    id: 2,
+    key: 'sui-eco',
+    name: 'Sui Eco Market'
   }
 }
 

--- a/packages/lending/src/market.ts
+++ b/packages/lending/src/market.ts
@@ -32,7 +32,7 @@ export const MARKETS = {
   rwa: {
     id: 3,
     key: 'rwa',
-    name: 'RWA Market'
+    name: 'Matrixdock Market'
   }
 }
 

--- a/packages/lending/src/market.ts
+++ b/packages/lending/src/market.ts
@@ -30,7 +30,7 @@ export const MARKETS = {
   //   name: 'Sui Eco Market'
   // },
   rwa: {
-    id: 3,
+    id: 2,
     key: 'rwa',
     name: 'Matrixdock Market'
   }

--- a/packages/lending/src/market.ts
+++ b/packages/lending/src/market.ts
@@ -28,6 +28,11 @@ export const MARKETS = {
     id: 2,
     key: 'sui-eco',
     name: 'Sui Eco Market'
+  },
+  rwa: {
+    id: 3,
+    key: 'rwa',
+    name: 'RWA Market'
   }
 }
 

--- a/packages/lending/src/market.ts
+++ b/packages/lending/src/market.ts
@@ -24,11 +24,11 @@ export const MARKETS = {
     key: 'ember',
     name: 'Ember Market'
   },
-  'sui-eco': {
-    id: 2,
-    key: 'sui-eco',
-    name: 'Sui Eco Market'
-  },
+  // 'sui-eco': {
+  //   id: 2,
+  //   key: 'sui-eco',
+  //   name: 'Sui Eco Market'
+  // },
   rwa: {
     id: 3,
     key: 'rwa',

--- a/packages/lending/src/pool.ts
+++ b/packages/lending/src/pool.ts
@@ -282,6 +282,7 @@ export async function depositCoinPTB(
   })
   const pool = await getPool(identifier, options)
   const market = options?.market || DEFAULT_MARKET_IDENTITY
+  const env = options?.env || 'prod'
 
   if (pool?.deprecatedAt && Date.now() > pool.deprecatedAt) {
     throw new Error(`The lending pool for coinType ${pool.suiCoinType} has been deprecated.`)
@@ -344,7 +345,7 @@ export async function depositCoinPTB(
   }
 
   // refresh stake for sui pool to balance the stake after deposit
-  if (config.version === 2 && pool.token.symbol === 'SUI') {
+  if (config.version === 2 && pool.token.symbol === 'SUI' && env === 'prod') {
     tx.moveCall({
       target: `${config.package}::pool::refresh_stake`,
       arguments: [tx.object(pool.contract.pool), tx.object('0x05')]

--- a/packages/lending/src/reward.ts
+++ b/packages/lending/src/reward.ts
@@ -374,7 +374,7 @@ export async function claimLendingRewardsPTB(
   for (const reward of rewards) {
     const { rewardCoinType, ruleIds, market, owner, address, emodeId } = reward
 
-    const key = `${rewardCoinType}___${address}`
+    const key = `${rewardCoinType}___${address}__${market}`
 
     for (const ruleId of ruleIds) {
       if (!rewardMap.has(key)) {
@@ -409,11 +409,17 @@ export async function claimLendingRewardsPTB(
       market
     })
     const coinType = rewardCoinType.split('___')[0]
-    const pool = pools.find((p) => normalizeCoinType(p.suiCoinType) === normalizeCoinType(coinType))
-    if (!pool || !pool.contract.rewardFundId) {
+    const filterPools = pools.filter(
+      (p) => normalizeCoinType(p.suiCoinType) === normalizeCoinType(coinType)
+    )
+    filterPools.sort((a, b) => (a.market === market ? -1 : 1))
+    const pool = filterPools[0]
+
+    const matchedRewardFund = config.rewardFunds[normalizeCoinType(coinType)]
+
+    if (!matchedRewardFund) {
       throw new Error(`No matching rewardFund found for reward coin: ${coinType} ${market}`)
     }
-    const matchedRewardFund = pool.contract.rewardFundId
 
     // Validate configuration
     if (options?.accountCap && !options.customCoinReceive) {
@@ -499,7 +505,10 @@ export async function claimLendingRewardsPTB(
             tx.pure.address(options.customCoinReceive.depositNAVI.fallbackReceiveAddress)
           )
         } else {
-          await depositCoinPTB(tx, pool, rewardCoin, options)
+          await depositCoinPTB(tx, pool, rewardCoin, {
+            ...options,
+            market: pool.market
+          })
         }
       } else {
         rewardCoins.push({

--- a/packages/lending/src/types.ts
+++ b/packages/lending/src/types.ts
@@ -364,8 +364,6 @@ export type Pool = {
     reserveId: string
     /** Pool address */
     pool: string
-    /** Optional reward fund ID */
-    rewardFundId?: string
   }
   /** Whether this pool is deprecated */
   isDeprecated: boolean
@@ -520,6 +518,7 @@ export type LendingConfig = {
       registryObject: string
     }
   }
+  rewardFunds: Record<string, string>
 }
 
 /**


### PR DESCRIPTION
## Description

Describe the changes or additions included in this PR.

## Test plan

How did you test the new or updated feature?

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes reward-claiming/deposit behavior and configuration schema (reward funds now come from `LendingConfig`), which could break integrations or route rewards to the wrong market if misconfigured. Market identity updates also affect how pools/rewards are grouped across markets.
> 
> **Overview**
> Bumps `@naviprotocol/lending` to `1.4.4` and updates market definitions by adding a new `rwa` (Matrixdock) market (with a placeholder commented `sui-eco` entry).
> 
> Refactors reward claiming to be *market-aware*: reward aggregation keys now include `market`, pool selection prefers pools matching the reward’s market, and the reward fund is pulled from `config.rewardFunds` (removing `Pool.contract.rewardFundId` from types). Also gates the SUI `refresh_stake` call during deposits to run only in `prod` environments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f82f597924a85977c42baab159db131dc4f1d99a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->