### PR TITLE
chore: bump astros bridge Mayan SDK

### DIFF
--- a/packages/astros-bridge-sdk/CHANGELOG.md
+++ b/packages/astros-bridge-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @naviprotocol/astros-bridge-sdk
 
+## 1.2.1
+
+### Patch Changes
+
+- Upgrade @mayanfinance/swap-sdk to 13.3.0.
+
 ## 1.2.0
 
 ### Minor Changes

--- a/packages/astros-bridge-sdk/package.json
+++ b/packages/astros-bridge-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@naviprotocol/astros-bridge-sdk",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "NAVI Astros Aggregator SDK",
   "license": "MIT",
   "keywords": [
@@ -50,7 +50,7 @@
     "typedoc": "typedoc"
   },
   "dependencies": {
-    "@mayanfinance/swap-sdk": "10.9.0",
+    "@mayanfinance/swap-sdk": "13.3.0",
     "@solana/web3.js": "1.98.2",
     "axios": "1.13.2",
     "ethers": "6.13.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,8 +175,8 @@ importers:
   packages/astros-bridge-sdk:
     dependencies:
       '@mayanfinance/swap-sdk':
-        specifier: 10.9.0
-        version: 10.9.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
+        specifier: 13.3.0
+        version: 13.3.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@solana/web3.js':
         specifier: 1.98.2
         version: 1.98.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
@@ -2071,8 +2071,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mayanfinance/swap-sdk@10.9.0':
-    resolution: {integrity: sha512-2bsu573wkvlU/oFPXat9z9+VUurTfuVOMXsWMNEZ2cgb2s9VQu3Sb0ejAYonCT9fUKUEzIrMb85LCeQu2BBkPw==}
+  '@mayanfinance/swap-sdk@13.3.0':
+    resolution: {integrity: sha512-wBsyJB4tTsVEdBeebBykK9KUiLziQ4hLnXomqB8/JT8MjWTCpN50gimAXK/TrepcHkZznQlMarqNNmbGCL9TZw==}
 
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
@@ -3209,6 +3209,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -5402,9 +5403,6 @@ packages:
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
 
-  js-sha256@0.9.0:
-    resolution: {integrity: sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==}
-
   js-sha3@0.8.0:
     resolution: {integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==}
 
@@ -6894,6 +6892,7 @@ packages:
   tar@7.4.4:
     resolution: {integrity: sha512-O1z7ajPkjTgEgmTGz0v9X4eqeEXTDREPTO77pVC1Nbs86feBU1Zhdg+edzavPmYW1olxkwsqA2v4uOw6E8LeDg==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
@@ -7286,6 +7285,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-to-istanbul@9.3.0:
@@ -7459,6 +7459,7 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
@@ -9463,15 +9464,15 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mayanfinance/swap-sdk@10.9.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)':
+  '@mayanfinance/swap-sdk@13.3.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@mysten/sui': 1.38.0(typescript@5.8.3)
+      '@noble/hashes': 1.8.0
       '@solana/buffer-layout': 4.0.1
       '@solana/web3.js': 1.98.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       bs58: 6.0.0
       cross-fetch: 3.2.0
       ethers: 6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      js-sha256: 0.9.0
       js-sha3: 0.8.0
     transitivePeerDependencies:
       - '@gql.tada/svelte-support'
@@ -13706,8 +13707,6 @@ snapshots:
   jiti@2.5.1: {}
 
   jju@1.4.0: {}
-
-  js-sha256@0.9.0: {}
 
   js-sha3@0.8.0: {}
 


### PR DESCRIPTION
## Summary
- bump @naviprotocol/astros-bridge-sdk to 1.2.1
- upgrade @mayanfinance/swap-sdk from 10.9.0 to 13.3.0
- update changelog and pnpm lockfile

## Test plan
- pnpm --filter @naviprotocol/astros-bridge-sdk build
- pnpm --filter @naviprotocol/astros-bridge-sdk lint
- pnpm --filter @naviprotocol/astros-bridge-sdk test

Note: no wallet signing or real bridge transaction was executed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades `@mayanfinance/swap-sdk` across a major version range, which could introduce behavioral or API changes in bridge execution even though no app code was modified.
> 
> **Overview**
> Updates `@naviprotocol/astros-bridge-sdk` version to `1.2.1` and records the release in `CHANGELOG.md`.
> 
> Upgrades the `@mayanfinance/swap-sdk` dependency from `10.9.0` to `13.3.0` and refreshes `pnpm-lock.yaml` accordingly (including transitive dependency changes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2acb70983fa89b64e4b9c8a5635f7b19df9605d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->