### PR TITLE
feat: lending-amount-snapshot-mismatch

### DIFF
--- a/packages/lending/CHANGELOG.md
+++ b/packages/lending/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @naviprotocol/lending
 
+## 1.4.4-beta.11
+
+### Patch Changes
+
+- Fix lending position amount drift right after deposit/withdraw/borrow/repay.
+  `getLendingStateBatch` now reads `supply_index` / `borrow_index` on-chain in
+  the same PTB as `get_user_state` (via `getter::get_reserve_data`) instead of
+  relying on the cached open-api `/api/navi/pools` snapshot, so the displayed
+  `supplyBalance` / `borrowBalance` no longer lags behind the chain by the
+  open-api indexer delay. Falls back to the pool indices from the open-api
+  response if reserve data cannot be decoded.
+
 ## 1.4.0
 
 ### Minor Changes

--- a/packages/lending/CHANGELOG.md
+++ b/packages/lending/CHANGELOG.md
@@ -11,6 +11,11 @@
   `supplyBalance` / `borrowBalance` no longer lags behind the chain by the
   open-api indexer delay. Falls back to the pool indices from the open-api
   response if reserve data cannot be decoded.
+- Guard the per-market `ReserveDataInfo` BCS decode with a `try/catch` so that
+  an unexpected on-chain layout (e.g. struct fields added in a future
+  contract upgrade) only causes that single market to fall back to the
+  open-api indices, instead of rejecting `getLendingStateBatch` and wiping
+  out every lending position for the user.
 
 ## 1.4.0
 

--- a/packages/lending/src/account.ts
+++ b/packages/lending/src/account.ts
@@ -25,7 +25,7 @@ import type {
   EModeCap
 } from './types'
 import { Transaction } from '@mysten/sui/transactions'
-import { UserStateInfo } from './bcs'
+import { UserStateInfo, ReserveDataInfo } from './bcs'
 import { getConfig, DEFAULT_CACHE_TIME } from './config'
 import {
   suiClient,
@@ -209,6 +209,28 @@ async function getLendingStateBatch(
   })
   const poolsMap = getPoolsMap(pools)
 
+  // Read the on-chain reserve indices for every market referenced by the
+  // tasks in the SAME PTB as get_user_state. This guarantees that
+  // supply_balance / borrow_balance and supply_index / borrow_index are
+  // captured from the exact same chain snapshot. Without this, indices come
+  // from the cached open-api /api/navi/pools response (typically lagging the
+  // chain by seconds to minutes), so right after a deposit/withdraw the
+  // displayed amount can drift by the interest accrued in between.
+  const uniqueMarketKeys = Array.from(new Set(tasks.map((task) => task.market)))
+  const uniqueMarkets = uniqueMarketKeys.map((key) => getMarketConfig(key))
+
+  for (const market of uniqueMarkets) {
+    const config = await getConfig({
+      ...options,
+      cacheTime: DEFAULT_CACHE_TIME,
+      market: market.key
+    })
+    tx.moveCall({
+      target: `${config.uiGetter}::getter::get_reserve_data`,
+      arguments: [tx.object(config.storage)]
+    })
+  }
+
   for (let task of tasks) {
     const config = await getConfig({
       ...options,
@@ -226,7 +248,32 @@ async function getLendingStateBatch(
     sender: address
   })
 
-  const stateList = (resp.results || []).map((result) => {
+  const results = resp.results || []
+
+  const reserveIndicesByMarket: Record<
+    string,
+    Record<number, { supplyIndex: string; borrowIndex: string }>
+  > = {}
+  uniqueMarkets.forEach((market, idx) => {
+    const reserves =
+      results[idx]?.returnValues?.map((item) => {
+        return bcs.vector(ReserveDataInfo as any).parse(Uint8Array.from(item[0]))
+      })[0] || []
+    const perAsset: Record<number, { supplyIndex: string; borrowIndex: string }> = {}
+    for (const reserve of reserves as Array<{
+      id: number
+      supply_index: string
+      borrow_index: string
+    }>) {
+      perAsset[reserve.id] = {
+        supplyIndex: reserve.supply_index,
+        borrowIndex: reserve.borrow_index
+      }
+    }
+    reserveIndicesByMarket[market.key] = perAsset
+  })
+
+  const stateList = results.slice(uniqueMarkets.length).map((result) => {
     return (
       result.returnValues?.map((item) => {
         return bcs.vector(UserStateInfo as any).parse(Uint8Array.from(item[0]))
@@ -243,6 +290,7 @@ async function getLendingStateBatch(
   stateList.forEach((states, index) => {
     const task = tasks[index]
     const market = getMarketConfig(task.market)
+    const marketReserves = reserveIndicesByMarket[market.key] || {}
     states.forEach((state) => {
       if (state.supply_balance === '0' && state.borrow_balance === '0') {
         if (task.emodeId === undefined) {
@@ -256,14 +304,15 @@ async function getLendingStateBatch(
       if (!pool) {
         return
       }
-      const supplyBalance = rayMathMulIndex(
-        state.supply_balance,
-        pool!.currentSupplyIndex
-      ).toString()
-      const borrowBalance = rayMathMulIndex(
-        state.borrow_balance,
-        pool!.currentBorrowIndex
-      ).toString()
+      // Prefer on-chain indices captured in the same PTB; fall back to the
+      // open-api pool indices only when reserve data could not be decoded
+      // for this asset (keeps behaviour backward compatible if the chain
+      // ever stops exposing getter::get_reserve_data).
+      const reserveIndices = marketReserves[state.asset_id]
+      const supplyIndex = reserveIndices?.supplyIndex ?? pool!.currentSupplyIndex
+      const borrowIndex = reserveIndices?.borrowIndex ?? pool!.currentBorrowIndex
+      const supplyBalance = rayMathMulIndex(state.supply_balance, supplyIndex).toString()
+      const borrowBalance = rayMathMulIndex(state.borrow_balance, borrowIndex).toString()
       result.push({
         supplyBalance,
         borrowBalance,

--- a/packages/lending/src/account.ts
+++ b/packages/lending/src/account.ts
@@ -29,7 +29,6 @@ import { UserStateInfo, ReserveDataInfo } from './bcs'
 import { getConfig, DEFAULT_CACHE_TIME } from './config'
 import {
   suiClient,
-  camelize,
   parseDevInspectResult,
   withSingleton,
   processContractHealthFactor,
@@ -49,7 +48,7 @@ import { getPool, PoolOperator, getPools } from './pool'
 import packageJson from '../package.json'
 import { getUserEModeCaps } from './emode'
 import BigNumber from 'bignumber.js'
-import { DEFAULT_MARKET_IDENTITY, getMarketConfig, MARKETS } from './market'
+import { getMarketConfig, MARKETS } from './market'
 
 /**
  * Merges multiple coins into a single coin for transaction building
@@ -255,22 +254,35 @@ async function getLendingStateBatch(
     Record<number, { supplyIndex: string; borrowIndex: string }>
   > = {}
   uniqueMarkets.forEach((market, idx) => {
-    const reserves =
-      results[idx]?.returnValues?.map((item) => {
-        return bcs.vector(ReserveDataInfo as any).parse(Uint8Array.from(item[0]))
-      })[0] || []
-    const perAsset: Record<number, { supplyIndex: string; borrowIndex: string }> = {}
-    for (const reserve of reserves as Array<{
-      id: number
-      supply_index: string
-      borrow_index: string
-    }>) {
-      perAsset[reserve.id] = {
-        supplyIndex: reserve.supply_index,
-        borrowIndex: reserve.borrow_index
+    try {
+      const reserves =
+        results[idx]?.returnValues?.map((item) => {
+          return bcs.vector(ReserveDataInfo as any).parse(Uint8Array.from(item[0]))
+        })[0] || []
+      const perAsset: Record<number, { supplyIndex: string; borrowIndex: string }> = {}
+      for (const reserve of reserves as Array<{
+        id: number
+        supply_index: string
+        borrow_index: string
+      }>) {
+        perAsset[reserve.id] = {
+          supplyIndex: reserve.supply_index,
+          borrowIndex: reserve.borrow_index
+        }
       }
+      reserveIndicesByMarket[market.key] = perAsset
+    } catch (e) {
+      // BCS decode failed (e.g. on-chain ReserveDataInfo layout changed and
+      // our schema is out of date). Leave the entry empty so the per-asset
+      // `?? pool.currentSupplyIndex` fallback below kicks in for this
+      // market only, preserving the original 1.4.4 behaviour for the
+      // affected market instead of turning a recoverable mismatch into a
+      // hard failure that wipes out every position for the user.
+      console.warn(
+        `[@naviprotocol/lending] Failed to decode reserve data for market "${market.key}", falling back to open-api pool indices`,
+        e
+      )
     }
-    reserveIndicesByMarket[market.key] = perAsset
   })
 
   const stateList = results.slice(uniqueMarkets.length).map((result) => {


### PR DESCRIPTION
## Description

Describe the changes or additions included in this PR.

## Test plan

How did you test the new or updated feature?

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core balance math in `getLendingStateBatch` used by positions and UI; incorrect parsing or PTB result ordering could misstate balances, though open-api fallback limits blast radius to affected markets.
> 
> **Overview**
> Fixes **display drift** for `supplyBalance` / `borrowBalance` right after deposit, withdraw, borrow, or repay.
> 
> **`getLendingStateBatch`** now issues **`getter::get_reserve_data`** for each unique market in the **same dev-inspect PTB** as **`get_user_state`**, then applies those on-chain **`supply_index` / `borrow_index`** when scaling balances via **`rayMathMulIndex`**. Previously indices came only from the cached open-api pools snapshot, which could lag the chain.
> 
> If reserve data cannot be decoded for a market, that market **falls back** to open-api pool indices. Per-market **`ReserveDataInfo`** BCS parsing is wrapped in **`try/catch`** so a layout mismatch on one market does not fail the whole batch. Changelog documents **1.4.4-beta.11**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a540665fb5a0bc0c7bc692cb14e7c18081582e09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->