### PR TITLE
Sui market

### DIFF
--- a/packages/lending/CHANGELOG.md
+++ b/packages/lending/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @naviprotocol/lending
 
+## 1.4.4-beta.11
+
+### Patch Changes
+
+- Fix lending position amount drift right after deposit/withdraw/borrow/repay.
+  `getLendingStateBatch` now reads `supply_index` / `borrow_index` on-chain in
+  the same PTB as `get_user_state` (via `getter::get_reserve_data`) instead of
+  relying on the cached open-api `/api/navi/pools` snapshot, so the displayed
+  `supplyBalance` / `borrowBalance` no longer lags behind the chain by the
+  open-api indexer delay. Falls back to the pool indices from the open-api
+  response if reserve data cannot be decoded.
+- Guard the per-market `ReserveDataInfo` BCS decode with a `try/catch` so that
+  an unexpected on-chain layout (e.g. struct fields added in a future
+  contract upgrade) only causes that single market to fall back to the
+  open-api indices, instead of rejecting `getLendingStateBatch` and wiping
+  out every lending position for the user.
+
 ## 1.4.0
 
 ### Minor Changes

--- a/packages/lending/CHANGELOG.md
+++ b/packages/lending/CHANGELOG.md
@@ -1,22 +1,5 @@
 # @naviprotocol/lending
 
-## 1.4.4-beta.11
-
-### Patch Changes
-
-- Fix lending position amount drift right after deposit/withdraw/borrow/repay.
-  `getLendingStateBatch` now reads `supply_index` / `borrow_index` on-chain in
-  the same PTB as `get_user_state` (via `getter::get_reserve_data`) instead of
-  relying on the cached open-api `/api/navi/pools` snapshot, so the displayed
-  `supplyBalance` / `borrowBalance` no longer lags behind the chain by the
-  open-api indexer delay. Falls back to the pool indices from the open-api
-  response if reserve data cannot be decoded.
-- Guard the per-market `ReserveDataInfo` BCS decode with a `try/catch` so that
-  an unexpected on-chain layout (e.g. struct fields added in a future
-  contract upgrade) only causes that single market to fall back to the
-  open-api indices, instead of rejecting `getLendingStateBatch` and wiping
-  out every lending position for the user.
-
 ## 1.4.0
 
 ### Minor Changes

--- a/packages/lending/package.json
+++ b/packages/lending/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@naviprotocol/lending",
-  "version": "1.4.4",
+  "version": "1.4.5-beta.1",
   "description": "NAVI Lending SDK",
   "license": "MIT",
   "keywords": [

--- a/packages/lending/package.json
+++ b/packages/lending/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@naviprotocol/lending",
-  "version": "1.4.5-beta.1",
+  "version": "1.4.5",
   "description": "NAVI Lending SDK",
   "license": "MIT",
   "keywords": [

--- a/packages/lending/src/account.ts
+++ b/packages/lending/src/account.ts
@@ -25,11 +25,10 @@ import type {
   EModeCap
 } from './types'
 import { Transaction } from '@mysten/sui/transactions'
-import { UserStateInfo } from './bcs'
+import { UserStateInfo, ReserveDataInfo } from './bcs'
 import { getConfig, DEFAULT_CACHE_TIME } from './config'
 import {
   suiClient,
-  camelize,
   parseDevInspectResult,
   withSingleton,
   processContractHealthFactor,
@@ -49,7 +48,7 @@ import { getPool, PoolOperator, getPools } from './pool'
 import packageJson from '../package.json'
 import { getUserEModeCaps } from './emode'
 import BigNumber from 'bignumber.js'
-import { DEFAULT_MARKET_IDENTITY, getMarketConfig, MARKETS } from './market'
+import { getMarketConfig, MARKETS } from './market'
 
 /**
  * Merges multiple coins into a single coin for transaction building
@@ -209,6 +208,28 @@ async function getLendingStateBatch(
   })
   const poolsMap = getPoolsMap(pools)
 
+  // Read the on-chain reserve indices for every market referenced by the
+  // tasks in the SAME PTB as get_user_state. This guarantees that
+  // supply_balance / borrow_balance and supply_index / borrow_index are
+  // captured from the exact same chain snapshot. Without this, indices come
+  // from the cached open-api /api/navi/pools response (typically lagging the
+  // chain by seconds to minutes), so right after a deposit/withdraw the
+  // displayed amount can drift by the interest accrued in between.
+  const uniqueMarketKeys = Array.from(new Set(tasks.map((task) => task.market)))
+  const uniqueMarkets = uniqueMarketKeys.map((key) => getMarketConfig(key))
+
+  for (const market of uniqueMarkets) {
+    const config = await getConfig({
+      ...options,
+      cacheTime: DEFAULT_CACHE_TIME,
+      market: market.key
+    })
+    tx.moveCall({
+      target: `${config.uiGetter}::getter::get_reserve_data`,
+      arguments: [tx.object(config.storage)]
+    })
+  }
+
   for (let task of tasks) {
     const config = await getConfig({
       ...options,
@@ -226,7 +247,45 @@ async function getLendingStateBatch(
     sender: address
   })
 
-  const stateList = (resp.results || []).map((result) => {
+  const results = resp.results || []
+
+  const reserveIndicesByMarket: Record<
+    string,
+    Record<number, { supplyIndex: string; borrowIndex: string }>
+  > = {}
+  uniqueMarkets.forEach((market, idx) => {
+    try {
+      const reserves =
+        results[idx]?.returnValues?.map((item) => {
+          return bcs.vector(ReserveDataInfo as any).parse(Uint8Array.from(item[0]))
+        })[0] || []
+      const perAsset: Record<number, { supplyIndex: string; borrowIndex: string }> = {}
+      for (const reserve of reserves as Array<{
+        id: number
+        supply_index: string
+        borrow_index: string
+      }>) {
+        perAsset[reserve.id] = {
+          supplyIndex: reserve.supply_index,
+          borrowIndex: reserve.borrow_index
+        }
+      }
+      reserveIndicesByMarket[market.key] = perAsset
+    } catch (e) {
+      // BCS decode failed (e.g. on-chain ReserveDataInfo layout changed and
+      // our schema is out of date). Leave the entry empty so the per-asset
+      // `?? pool.currentSupplyIndex` fallback below kicks in for this
+      // market only, preserving the original 1.4.4 behaviour for the
+      // affected market instead of turning a recoverable mismatch into a
+      // hard failure that wipes out every position for the user.
+      console.warn(
+        `[@naviprotocol/lending] Failed to decode reserve data for market "${market.key}", falling back to open-api pool indices`,
+        e
+      )
+    }
+  })
+
+  const stateList = results.slice(uniqueMarkets.length).map((result) => {
     return (
       result.returnValues?.map((item) => {
         return bcs.vector(UserStateInfo as any).parse(Uint8Array.from(item[0]))
@@ -243,6 +302,7 @@ async function getLendingStateBatch(
   stateList.forEach((states, index) => {
     const task = tasks[index]
     const market = getMarketConfig(task.market)
+    const marketReserves = reserveIndicesByMarket[market.key] || {}
     states.forEach((state) => {
       if (state.supply_balance === '0' && state.borrow_balance === '0') {
         if (task.emodeId === undefined) {
@@ -256,14 +316,15 @@ async function getLendingStateBatch(
       if (!pool) {
         return
       }
-      const supplyBalance = rayMathMulIndex(
-        state.supply_balance,
-        pool!.currentSupplyIndex
-      ).toString()
-      const borrowBalance = rayMathMulIndex(
-        state.borrow_balance,
-        pool!.currentBorrowIndex
-      ).toString()
+      // Prefer on-chain indices captured in the same PTB; fall back to the
+      // open-api pool indices only when reserve data could not be decoded
+      // for this asset (keeps behaviour backward compatible if the chain
+      // ever stops exposing getter::get_reserve_data).
+      const reserveIndices = marketReserves[state.asset_id]
+      const supplyIndex = reserveIndices?.supplyIndex ?? pool!.currentSupplyIndex
+      const borrowIndex = reserveIndices?.borrowIndex ?? pool!.currentBorrowIndex
+      const supplyBalance = rayMathMulIndex(state.supply_balance, supplyIndex).toString()
+      const borrowBalance = rayMathMulIndex(state.borrow_balance, borrowIndex).toString()
       result.push({
         supplyBalance,
         borrowBalance,

--- a/packages/lending/src/market.ts
+++ b/packages/lending/src/market.ts
@@ -24,15 +24,15 @@ export const MARKETS = {
     key: 'ember',
     name: 'Ember Market'
   },
-  // 'sui-eco': {
-  //   id: 2,
-  //   key: 'sui-eco',
-  //   name: 'Sui Eco Market'
-  // },
   rwa: {
     id: 2,
     key: 'rwa',
     name: 'Matrixdock Market'
+  },
+  'sui-eco': {
+    id: 3,
+    key: 'sui-eco',
+    name: 'Sui Eco Market'
   }
 }
 


### PR DESCRIPTION
## Description

Describe the changes or additions included in this PR.

## Test plan

How did you test the new or updated feature?

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how displayed balances and position USD values are derived for all lending reads; incorrect PTB ordering or BCS parsing could skew amounts until fallback applies. Enabling `sui-eco` expands default multi-market queries and assumes id 3 matches protocol expectations.
> 
> **Overview**
> **User-facing supply/borrow amounts** from `getLendingState` / `getLendingPositions` are computed with **on-chain** supply and borrow indices fetched via `getter::get_reserve_data` in the **same** `devInspect` PTB as `get_user_state`, instead of indices from the cached open-api pools feed. That removes post-deposit/withdraw drift when API indices lag the chain. If `ReserveDataInfo` BCS decode fails for a market, that market alone falls back to the previous open-api pool indices (warn + no hard failure).
> 
> **Markets:** **`sui-eco`** is added back to `MARKETS` as **id 3** (“Sui Eco Market”); **`rwa`** remains id 2.
> 
> Package version **1.4.4 → 1.4.5**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aef751a1261c55d56baf3b1c4acae1fdc7ab1097. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->