### PR TITLE
refactor: improve readability of depositCoinPTB and repayCoinPTB func…

### DIFF
--- a/packages/lending/src/pool.ts
+++ b/packages/lending/src/pool.ts
@@ -345,7 +345,7 @@ export async function depositCoinPTB(
   }
 
   // refresh stake for sui pool to balance the stake after deposit
-  if (config.version === 2 && pool.token.symbol === 'SUI' && env === 'prod') {
+  if (config.version === 2 && pool.token.symbol === 'SUI' && env === 'prod' && market === 'main') {
     tx.moveCall({
       target: `${config.package}::pool::refresh_stake`,
       arguments: [tx.object(pool.contract.pool), tx.object('0x05')]


### PR DESCRIPTION
…tions by restructuring type definitions and adding market condition for stake refresh

## Description

Describe the changes or additions included in this PR.

## Test plan

How did you test the new or updated feature?

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes deposit transaction composition for non-main markets on prod SUI pools; main-market behavior is unchanged but incorrect stake refresh on other markets could have masked issues.
> 
> **Overview**
> **`depositCoinPTB`** no longer appends **`pool::refresh_stake`** after every prod SUI deposit on config v2. The post-deposit stake refresh now runs only when **`market === 'main'`**, in addition to the existing checks (SUI pool, prod, v2).
> 
> Deposits on other markets skip that extra move call, so their PTBs differ from main-market SUI deposits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66926d6b632e5ce9e69f329582052b43e3949cf5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->