### PR TITLE
chore: bump version to 1.4.6 in lending package.json

### DIFF
--- a/packages/lending/package.json
+++ b/packages/lending/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@naviprotocol/lending",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "NAVI Lending SDK",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
## Description

Describe the changes or additions included in this PR.

## Test plan

How did you test the new or updated feature?

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single metadata version field change with no runtime or API code modifications.
> 
> **Overview**
> Bumps the published semver for **`@naviprotocol/lending`** from **1.4.5** to **1.4.6** in `packages/lending/package.json`. No source, build, or dependency changes are included in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c179100624cc037064cf2c1ac81fe325d130f553. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->