### PR TITLE
fix(lending): attribute e-mode positions by account cap

### DIFF
--- a/packages/lending/src/account.ts
+++ b/packages/lending/src/account.ts
@@ -191,6 +191,7 @@ async function getLendingStateBatch(
     address: string
     market: string
     emodeId?: number
+    accountCap?: string
   }[],
   options?: Partial<
     SuiClientOption &
@@ -331,7 +332,8 @@ async function getLendingStateBatch(
         assetId: state.asset_id,
         market: market.key,
         pool,
-        emodeId: task.emodeId
+        emodeId: task.emodeId,
+        accountCap: task.accountCap
       })
     })
   })
@@ -591,7 +593,8 @@ export const getLendingPositions = withCache(
             return {
               address: emodeCap.accountCap,
               market: getMarketConfig(emodeCap.marketId).key,
-              emodeId: emodeCap.emodeId
+              emodeId: emodeCap.emodeId,
+              accountCap: emodeCap.accountCap
             }
           })
       )
@@ -599,12 +602,19 @@ export const getLendingPositions = withCache(
     const lendingStates = await getLendingStateBatch(address, tasks, options)
 
     lendingStates.forEach((lendingState) => {
+      // Attribute the state to its exact account cap. A user can hold multiple
+      // caps under the same emodeId (e.g. both directions of a bidirectional
+      // pair), so we match by the accountCap carried on the task rather than by
+      // emodeId, which would collapse every same-emodeId cap onto the first one.
       const emodeCap =
         typeof lendingState.emodeId === 'number'
-          ? emodeCaps.find((cap) => {
+          ? ((lendingState.accountCap
+              ? emodeCaps.find((cap) => cap.accountCap === lendingState.accountCap)
+              : undefined) ??
+            emodeCaps.find((cap) => {
               const market = getMarketConfig(lendingState.market)
               return cap.emodeId === lendingState.emodeId && cap.marketId === market.id
-            })
+            }))
           : undefined
       if (emodeCap) {
         const inEmode = lendingState.pool.emodes.find((emode) => emode.emodeId === emodeCap.emodeId)

--- a/packages/lending/src/types.ts
+++ b/packages/lending/src/types.ts
@@ -127,6 +127,13 @@ export type UserLendingInfo = {
   pool: Pool
   market: string
   emodeId?: number
+  /**
+   * The E-Mode account cap object id this state belongs to. Set only for
+   * E-Mode tasks. A user can hold multiple account caps under the SAME
+   * emodeId (e.g. both directions of a bidirectional pair), so positions must
+   * be attributed by accountCap rather than emodeId alone.
+   */
+  accountCap?: string
 }
 
 /**


### PR DESCRIPTION
getLendingPositions matched each on-chain state to an e-mode cap by emodeId + marketId via Array.find, which collapses every cap sharing the same emodeId onto the first one. A user can hold multiple account caps under the same emodeId (e.g. both directions of a bidirectional pair), so their positions were merged incorrectly.

Carry the originating accountCap through getLendingStateBatch and match positions by accountCap, falling back to the previous emodeId match when accountCap is absent. UserLendingInfo now exposes the optional accountCap.

## Description

Describe the changes or additions included in this PR.

## Test plan

How did you test the new or updated feature?

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized correctness fix in position attribution with a backward-compatible fallback when accountCap is absent; no auth or on-chain transaction logic changes.
> 
> **Overview**
> Fixes **incorrect merging of E-Mode lending positions** when a wallet holds more than one account cap with the same `emodeId` (e.g. both sides of a bidirectional pair).
> 
> `getLendingStateBatch` now threads **`accountCap`** on E-Mode tasks and returns it on **`UserLendingInfo`**. **`getLendingPositions`** resolves the matching cap by **`accountCap` first**, with the previous **`emodeId` + market** lookup only as a fallback when `accountCap` is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fdd101833c5bf229e63038d6765daf4a84b8c5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->