### PR TITLE
fix(aggregator-sdk): point magma integrate package at on-chain v4

### DIFF
--- a/.changeset/fix-magma-integrate-v4.md
+++ b/.changeset/fix-magma-integrate-v4.md
@@ -1,0 +1,12 @@
+---
+"@naviprotocol/astros-aggregator-sdk": patch
+---
+
+fix(aggregator-sdk): update magma integrate package to on-chain v4
+
+Magma upgraded its on-chain GlobalConfig.package_version to 4 and enforces it via
+config::checked_package_version. The previous integrate package (0x4a9d6fb6, synced from
+@magmaprotocol/magma-ts-sdk@1.1.1) is pre-v4, so router::swap aborted with code 10 on real
+swaps (preswap was unaffected, masking the issue). Point magmaIntegratePublishedAt at the
+current v4 integrate package 0x668909f9. Verified via devInspect: SUI->USDC and USDC->SUI
+both succeed.

--- a/packages/astros-aggregator-sdk/src/libs/Aggregator/config.ts
+++ b/packages/astros-aggregator-sdk/src/libs/Aggregator/config.ts
@@ -94,7 +94,12 @@ export const AggregatorConfig = {
   // Synced with @magmaprotocol/magma-ts-sdk@1.1.1 almm_pool / almmConfig values.
   magmaAlmmPackageId: '0x532bf64e6f0bf702353387d53a28a3239249f47c39d58954f2c0a1f9f4436c20',
   magmaAlmmPublishedAt: '0x8800c3f7496a09dd62b0850b178b73ada2aeaf34d076dcd1c1bbd0da0015550d',
-  magmaIntegratePublishedAt: '0x4a9d6fb6f34ca8918756c2dfddf8f0a7fd5ef590bcffa6c03db24a6f10f42c5e',
+  // magmaIntegratePublishedAt is the package whose router::swap we call (see Dex/magma.ts).
+  // It must track magma's on-chain GlobalConfig.package_version (currently 4). The value
+  // from @magmaprotocol/magma-ts-sdk@1.1.1 (0x4a9d6fb6) is pre-v4 and aborts in
+  // config::checked_package_version (code 10); 0x668909f9 is the current v4 integrate
+  // package (verified by devInspect on both SUI->USDC and USDC->SUI).
+  magmaIntegratePublishedAt: '0x668909f9f30380dd1b63834534dc2bd19b274e6312a0dfa9be0ee5b0cef73446',
   magmaAlmmFactory: '0xedb456e93e423dd75a8ddebedd9974bb661195043027e32ce01649d6ccee74cf'
 }
 


### PR DESCRIPTION
Magma enforces GlobalConfig.package_version (now 4) via config::checked_package_version. The integrate package synced from magma-ts-sdk@1.1.1 (0x4a9d6fb6) is pre-v4, so magma router::swap aborted with code 10 on real swaps while preswap stayed green. Update magmaIntegratePublishedAt to the current v4 package 0x668909f9. Verified by devInspect: SUI->USDC and USDC->SUI both succeed.

## Description

Describe the changes or additions included in this PR.

## Test plan

How did you test the new or updated feature?

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the on-chain package used for live Magma swap execution; wrong address would break swaps, but scope is a single verified constant update.
> 
> **Overview**
> Updates **`magmaIntegratePublishedAt`** in `AggregatorConfig` from the pre-v4 integrate package (`0x4a9d6fb6…`, aligned with `@magmaprotocol/magma-ts-sdk@1.1.1`) to the current v4 integrate package **`0x668909f9…`**, so Magma **`router::swap`** PTBs pass on-chain **`config::checked_package_version`** (GlobalConfig **`package_version`** is 4). Without this, real swaps abort with **code 10** while preswap can still look fine.
> 
> Inline comments document that this address must track Magma’s on-chain package version, not only the TS SDK pin. A patch **changeset** records the fix for **`@naviprotocol/astros-aggregator-sdk`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb89174f0673fb962001f502c38163d71f2014f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->