### PR TITLE
fix(aggregator-sdk): bump find_routes version to 14 for magma v4 gating

### DIFF
--- a/.changeset/bump-quote-version-14.md
+++ b/.changeset/bump-quote-version-14.md
@@ -1,0 +1,9 @@
+---
+"@naviprotocol/astros-aggregator-sdk": patch
+---
+
+fix(aggregator-sdk): bump find_routes version 13 -> 14 for magma v4 gating
+
+Pairs with the magma v4 integrate package fix. The router API gates magma routes behind a
+minimum client version; bumping the request version to 14 lets the backend return magma only
+to clients running this (fixed) SDK, while older clients keep getting magma-free routes.

--- a/packages/astros-aggregator-sdk/src/libs/Aggregator/getQuote.ts
+++ b/packages/astros-aggregator-sdk/src/libs/Aggregator/getQuote.ts
@@ -57,7 +57,10 @@ export async function getQuoteInternal(
     by_amount_in:
       swapOptions?.byAmountIn !== undefined ? swapOptions.byAmountIn.toString() : 'true',
     depth: swapOptions?.depth !== undefined ? swapOptions.depth.toString() : '3',
-    version: '13'
+    // Bumped 13 -> 14 alongside the magma v4 integrate package fix: the router API only
+    // returns magma routes to version >= 14 clients (this SDK), so older clients that still
+    // build the pre-v4 magma PTB don't get magma and avoid the on-chain abort.
+    version: '14'
   }).toString()
 
   // Construct dex provider string if dexList is provided


### PR DESCRIPTION
The router API gates magma routes behind a minimum client version. Bump the find_routes request version 13 -> 14 so the backend returns magma only to clients on this SDK (which build the magma swap PTB with the v4 integrate package 0x668909f9); older clients keep getting magma-free routes and avoid the on-chain router::swap abort.

## Description

Describe the changes or additions included in this PR.

## Test plan

How did you test the new or updated feature?

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single query-parameter change with no auth or data-model impact; behavior is intentionally gated server-side to reduce swap risk for old clients.
> 
> **Overview**
> Raises the **`find_routes` query `version`** sent by `getQuoteInternal` from **13 to 14**, aligned with the magma v4 integrate-package fix elsewhere in the SDK.
> 
> The aggregator router only includes **magma** legs for clients at **version ≥ 14**, so upgraded SDKs get magma routes with the correct PTB while older clients still receive magma-free quotes and avoid **`router::swap`** on-chain aborts from legacy integrate builds.
> 
> A **patch changeset** records the release for `@naviprotocol/astros-aggregator-sdk`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 385df8393ac9f4c23c4d42a952cb03f10d5dee7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->