### PR TITLE
fix(astros-sdk): bump kriya v3 package to on-chain v4

### DIFF
--- a/packages/astros-aggregator-sdk/package.json
+++ b/packages/astros-aggregator-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@naviprotocol/astros-aggregator-sdk",
-  "version": "1.14.3",
+  "version": "1.14.4",
   "description": "NAVI Astros Aggregator SDK",
   "license": "MIT",
   "keywords": [

--- a/packages/astros-aggregator-sdk/src/libs/Aggregator/config.ts
+++ b/packages/astros-aggregator-sdk/src/libs/Aggregator/config.ts
@@ -37,8 +37,12 @@ export const AggregatorConfig = {
   turbosPackageId: '0xa5a0c25c79e428eba04fb98b3fb2a34db45ab26d4c8faf0d7e39d66a63891e64',
 
   // Kriya DEX configuration (V2 and V3)
+  // kriyaV3Version is the shared version registry object (unchanged across upgrades).
+  // kriyaV3PackageId must track kriya's on-chain latest package; trade::flash_swap
+  // version-gates via version::assert_supported_version (abort 69) when stale.
+  // Bumped v2 (0xbd8d…) → v4 (0x0d7305a7…), the current on-chain version.
   kriyaV3Version: '0xf5145a7ac345ca8736cf8c76047d00d6d378f30e81be6f6eb557184d9de93c78',
-  kriyaV3PackageId: '0xbd8d4489782042c6fafad4de4bc6a5e0b84a43c6c00647ffd7062d1e2bb7549e',
+  kriyaV3PackageId: '0x0d7305a7475ed54adc905365bd081939a81926636b4c438cf2f75f4924b8d960',
   kriyaV2PackageId: '0xa0eba10b173538c8fecca1dff298e488402cc9ff374f8a12ca7758eebe830b66',
 
   // System clock address


### PR DESCRIPTION
## 背景和目标
Kriya 已把发布包升级到 **v4**。SDK 里 `kriyaV3PackageId` 仍指向旧的 **v2**（`0xbd8d…`），导致经 Kriya V3 路由的主网 swap 在 `trade::flash_swap` 内触发 **abort 69**（`version::assert_supported_version`）。目标：把该值更到链上当前 v4，恢复 Kriya swap。

## 主要改动
- `config.ts`：`kriyaV3PackageId` `0xbd8d…` → **v4 `0x0d7305a7…`**（链上当前版本，经 GraphQL `packageVersions` 核实为最新）。
- `kriyaV3Version`（共享 version registry 对象，升级时不变）**保持不变**。
- 版本 bump `1.14.3` → **`1.14.4`**。

## 关联任务
Sui JSON-RPC/包版本对齐（kriya v4）。

## 敏感信息自检
无密钥/凭证；仅链上公开 package object id。

## 验证结果
- 通过 GraphQL `packageVersions` 确认 kriya 版本链 v1→v4，`0x0d7305a7…` 为最新 v4。
- 后端 `compute_swap_result` 在 v2 与 v4 上真链报价数学等价（1 SUI → 748264，一致），确认 v4 包函数可用、无回归。

## 风险和回滚
- 风险低：单一常量指向更新的同族升级包；类型定义包不变，池/类型解析不受影响。
- 回滚：还原 `kriyaV3PackageId` 到 `0xbd8d…` 并回退版本号即可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single public on-chain package id constant change with no auth or data-path changes; wrong id would only break Kriya V3 swaps until reverted.
> 
> **Overview**
> Updates **`kriyaV3PackageId`** in aggregator config from the stale **v2** package to Kriya’s current on-chain **v4** package so Kriya V3 routes no longer fail **`trade::flash_swap`** with **abort 69** from **`version::assert_supported_version`**.
> 
> **`kriyaV3Version`** (shared version registry) is unchanged; inline comments document that the package id must track the latest published package. SDK release is bumped **1.14.3 → 1.14.4** (plus a trivial **`package.json`** EOF newline fix).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83b8116dbb90b8fa4d260496a628bcf73ddcc9e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->