### PR TITLE
chore(release): bump versions for astros-aggregator-sdk and wallet-cl…

### DIFF
--- a/packages/astros-aggregator-sdk/package.json
+++ b/packages/astros-aggregator-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@naviprotocol/astros-aggregator-sdk",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "NAVI Astros Aggregator SDK",
   "license": "MIT",
   "type": "module",

--- a/packages/lending/package.json
+++ b/packages/lending/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@naviprotocol/lending",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "NAVI Lending SDK",
   "license": "MIT",
   "type": "module",

--- a/packages/wallet-client/package.json
+++ b/packages/wallet-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@naviprotocol/wallet-client",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "NAVI Wallet Client",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
…ient to 2.0.2 and 2.0.1 respectively

## Description

Describe the changes or additions included in this PR.

## Test plan

How did you test the new or updated feature?

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Metadata-only version bumps with no logic or dependency changes in the diff.
> 
> **Overview**
> This PR is a **release-only** change: it bumps published semver in three workspace packages and does not modify runtime code, APIs, or build config beyond those version strings.
> 
> **`@naviprotocol/astros-aggregator-sdk`** goes from **2.0.1 → 2.0.2**, **`@naviprotocol/wallet-client`** from **2.0.1 → 2.0.2**, and **`@naviprotocol/lending`** from **2.0.0 → 2.0.1**. No other `package.json` files in the diff are touched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96e9e08af33b3397161f826d6d330d81d09afd22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->