### PR TITLE
refactor(oracle): streamline price update logic and clean up type def…

### DIFF
--- a/packages/lending/src/oracle.ts
+++ b/packages/lending/src/oracle.ts
@@ -264,32 +264,18 @@ export async function updateOraclePricesPTB(
 
   // Update individual price feeds in the oracle contract
   for (const priceFeed of priceFeeds) {
-    if (options?.env === 'dev') {
-      tx.moveCall({
-        target: `${config.oracle.packageId}::oracle_pro::update_single_price`,
-        arguments: [
-          tx.object('0x6'), // Clock object
-          tx.object(config.oracle.oracleConfig), // Oracle configuration
-          tx.object(config.oracle.priceOracle), // Price oracle contract
-          tx.object(config.oracle.supraOracleHolder), // Supra oracle holder
-          tx.object(priceFeed.pythPriceInfoObject), // Pyth price info object
-          tx.pure.address(priceFeed.feedId) // Price feed ID
-        ]
-      })
-    } else {
-      tx.moveCall({
-        target: `${config.oracle.packageId}::oracle_pro::update_single_price_v2`,
-        arguments: [
-          tx.object('0x6'), // Clock object
-          tx.object(config.oracle.oracleConfig), // Oracle configuration
-          tx.object(config.oracle.priceOracle), // Price oracle contract
-          tx.object(config.oracle.supraOracleHolder), // Supra oracle holder
-          tx.object(priceFeed.pythPriceInfoObject), // Pyth price info object
-          tx.object(config.oracle.switchboardAggregator),
-          tx.pure.address(priceFeed.feedId) // Price feed ID
-        ]
-      })
-    }
+    tx.moveCall({
+      target: `${config.oracle.packageId}::oracle_pro::update_single_price_v2`,
+      arguments: [
+        tx.object('0x6'), // Clock object
+        tx.object(config.oracle.oracleConfig), // Oracle configuration
+        tx.object(config.oracle.priceOracle), // Price oracle contract
+        tx.object(config.oracle.supraOracleHolder), // Supra oracle holder
+        tx.object(priceFeed.pythPriceInfoObject), // Pyth price info object
+        tx.object(config.oracle.switchboardAggregator),
+        tx.pure.address(priceFeed.feedId) // Price feed ID
+      ]
+    })
   }
   return tx
 }


### PR DESCRIPTION
…initions

## Description

Describe the changes or additions included in this PR.

## Test plan

How did you test the new or updated feature?

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how on-chain oracle prices are refreshed for all environments, including dev; misconfigured Switchboard or dev config could break price updates used by lending operations.
> 
> **Overview**
> **Oracle price PTBs now always use the v2 on-chain entrypoint.** In `updateOraclePricesPTB`, the `options?.env === 'dev'` branch that called `oracle_pro::update_single_price` (without Switchboard) was removed. Every feed update now appends a single `update_single_price_v2` move call, including `config.oracle.switchboardAggregator` in the arguments.
> 
> This unifies dev and non-dev transaction building for lending oracle refreshes; dev environments that relied on the legacy entrypoint must have Switchboard wired in config like production.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ed152b18b03f083ea023cc9020edbc840962bf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->