### PR TITLE
fix(lending): fetch pyth price table entries as plain dynamic fields …

### DIFF
--- a/.changeset/pyth-price-table-plain-dynamic-field.md
+++ b/.changeset/pyth-price-table-plain-dynamic-field.md
@@ -1,5 +1,0 @@
----
-'@naviprotocol/lending': patch
----
-
-Fix Pyth price feed updates on the v2 Core (gRPC) client: price table entries are plain dynamic fields, so they are now fetched via `getDynamicField` instead of `getDynamicObjectField`, whose `Wrapper<PriceIdentifier>` derivation resolved to a nonexistent object and aborted every price refresh ("failed to update pyth price feeds, msg: Object 0x...").

--- a/.changeset/pyth-price-table-plain-dynamic-field.md
+++ b/.changeset/pyth-price-table-plain-dynamic-field.md
@@ -1,0 +1,5 @@
+---
+'@naviprotocol/lending': patch
+---
+
+Fix Pyth price feed updates on the v2 Core (gRPC) client: price table entries are plain dynamic fields, so they are now fetched via `getDynamicField` instead of `getDynamicObjectField`, whose `Wrapper<PriceIdentifier>` derivation resolved to a nonexistent object and aborted every price refresh ("failed to update pyth price feeds, msg: Object 0x...").

--- a/packages/lending/CHANGELOG.md
+++ b/packages/lending/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @naviprotocol/lending
 
+## 2.0.4
+
+### Patch Changes
+
+- 2ae3e35: Fix Pyth price feed updates on the v2 Core (gRPC) client: price table entries are plain dynamic fields, so they are now fetched via `getDynamicField` instead of `getDynamicObjectField`, whose `Wrapper<PriceIdentifier>` derivation resolved to a nonexistent object and aborted every price refresh ("failed to update pyth price feeds, msg: Object 0x...").
+
 ## 2.0.0-beta.1
 
 ### Patch Changes

--- a/packages/lending/package.json
+++ b/packages/lending/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@naviprotocol/lending",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "NAVI Lending SDK",
   "license": "MIT",
   "type": "module",

--- a/packages/lending/src/pyth.ts
+++ b/packages/lending/src/pyth.ts
@@ -55,6 +55,9 @@ type SuiPythCoreProvider = {
   }): Promise<{
     object?: { objectId: string; type?: string; json?: Record<string, unknown> | null }
   }>
+  getDynamicField(options: { parentId: string; name: CoreDynamicFieldName }): Promise<{
+    dynamicField?: { value?: { type?: string; bcs?: Uint8Array } }
+  }>
 }
 
 const MAX_ARGUMENT_SIZE = 16 * 1024
@@ -248,7 +251,8 @@ export class SuiPythClient {
     if (
       core &&
       typeof core.getObject === 'function' &&
-      typeof core.getDynamicObjectField === 'function'
+      typeof core.getDynamicObjectField === 'function' &&
+      typeof core.getDynamicField === 'function'
     ) {
       return core as SuiPythCoreProvider
     }
@@ -465,22 +469,38 @@ export class SuiPythClient {
     const normalizedFeedId = normalizePriceId(feedId)
     if (!this.priceFeedObjectIdCache.has(normalizedFeedId)) {
       const { id: tableId, fieldType } = await this.getPriceTableInfo()
-      const fieldName = this.getCoreProvider()
-        ? toDynamicFieldName(
-            `${fieldType}::price_identifier::PriceIdentifier`,
-            encodePriceIdentifier(hexToBytes(normalizedFeedId))
-          )
-        : {
-            type: `${fieldType}::price_identifier::PriceIdentifier`,
-            value: {
-              bytes: Array.from(hexToBytes(normalizedFeedId))
-            }
-          }
-      const result = await this.getDynamicMoveObjectJson(tableId, fieldName)
-      if (!result?.fields) {
-        this.priceFeedObjectIdCache.set(normalizedFeedId, undefined)
+      const nameType = `${fieldType}::price_identifier::PriceIdentifier`
+
+      const core = this.getCoreProvider()
+      if (core) {
+        // Pyth's price table stores entries as plain dynamic fields
+        // (0x2::dynamic_field::Field<PriceIdentifier, ID>). getDynamicObjectField
+        // must not be used here: it derives the child id from
+        // Wrapper<PriceIdentifier> and resolves to an object that does not exist
+        // on chain, aborting every Pyth price feed update.
+        const { dynamicField } = await core.getDynamicField({
+          parentId: tableId,
+          name: toDynamicFieldName(nameType, encodePriceIdentifier(hexToBytes(normalizedFeedId)))
+        })
+        const valueBcs = dynamicField?.value?.bcs
+        this.priceFeedObjectIdCache.set(
+          normalizedFeedId,
+          valueBcs && valueBcs.length === 32
+            ? bcs.Address.parse(Uint8Array.from(valueBcs))
+            : undefined
+        )
       } else {
-        this.priceFeedObjectIdCache.set(normalizedFeedId, (result.fields as any).value)
+        const result = await this.getDynamicMoveObjectJson(tableId, {
+          type: nameType,
+          value: {
+            bytes: Array.from(hexToBytes(normalizedFeedId))
+          }
+        })
+        if (!result?.fields) {
+          this.priceFeedObjectIdCache.set(normalizedFeedId, undefined)
+        } else {
+          this.priceFeedObjectIdCache.set(normalizedFeedId, (result.fields as any).value)
+        }
       }
     }
     return this.priceFeedObjectIdCache.get(normalizedFeedId)

--- a/packages/lending/tests/pyth.test.ts
+++ b/packages/lending/tests/pyth.test.ts
@@ -284,13 +284,28 @@ describe('SuiPythClient', () => {
               }
             }
 
+            throw new Error(`unexpected dynamic object field parent ${parentId}`)
+          }
+        ),
+        getDynamicField: vi.fn(
+          async ({
+            parentId,
+            name
+          }: {
+            parentId: string
+            name: { type: string; bcs: Uint8Array }
+          }) => {
             if (parentId === priceTableId) {
               expect(name.type).toBe(`${pythPackageId}::price_identifier::PriceIdentifier`)
+              expect(Array.from(name.bcs)).toEqual([
+                0x20,
+                ...Array.from(Uint8Array.from({ length: 32 }, () => 0xbb))
+              ])
               return {
-                object: {
-                  objectId: priceInfoObjectId,
-                  json: {
-                    value: priceInfoObjectId
+                dynamicField: {
+                  value: {
+                    type: `${normalizedSystemPackage}::object::ID`,
+                    bcs: Uint8Array.from({ length: 32 }, () => 0x66)
                   }
                 }
               }
@@ -317,5 +332,11 @@ describe('SuiPythClient', () => {
       objectId: wormholeStateId,
       include: { json: true }
     })
+    // The state's `price_info` entry is a dynamic object field, but the price
+    // table entries are plain dynamic fields: fetching them through
+    // getDynamicObjectField derives a Wrapper<PriceIdentifier> child id that
+    // does not exist on chain.
+    expect(provider.core.getDynamicObjectField).toHaveBeenCalledTimes(1)
+    expect(provider.core.getDynamicField).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/wallet-client/CHANGELOG.md
+++ b/packages/wallet-client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @naviprotocol/wallet-client
 
+## 2.0.4
+
+### Patch Changes
+
+- Updated dependencies [2ae3e35]
+  - @naviprotocol/lending@2.0.4
+
 ## 2.0.1
 
 ### Patch Changes

--- a/packages/wallet-client/package.json
+++ b/packages/wallet-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@naviprotocol/wallet-client",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "NAVI Wallet Client",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Title: fix(lending): fetch Pyth price table entries as plain dynamic fields on Core client

## Description

Fixes a stage-only failure where any supply that triggers a Pyth price refresh aborts with:

```
Error: failed to update pyth price feeds, msg: Object 0x82eedd361947837355b7d35233e9a5c9aaa14560c6839efc0628ce0181697942
```

Reproduced on `https://lending-stage.vercel.app/pool?coinType=...::eacred::EACRED&market=ember`. Prod is unaffected because it still goes through the legacy JSON-RPC provider path.

**Root cause.** The object ID in the error exists in no config and not on chain — it is a client-side derived dynamic field ID, derived with the wrong scheme. Pyth's price table (`Table<PriceIdentifier, ID>`, id `0x234c9ffc...`) stores its entries as plain dynamic fields (`0x2::dynamic_field::Field<PriceIdentifier, ID>`), but `SuiPythClient.getPriceFeedObjectId` on the Core (gRPC) path looked them up via `core.getDynamicObjectField`, which wraps the name type in `0x2::dynamic_object_field::Wrapper<K>` before deriving the child object ID. Verified by re-deriving both IDs for the EACRED feed (`0x40ac33...`):

| Derivation | Result |
|---|---|
| plain `Field<PriceIdentifier, ID>` | `0xcc69e185...f874a901` — exists on chain ✅ |
| `Wrapper<PriceIdentifier>` (dynamic object field) | `0x82eedd36...81697942` — exactly the error ID ❌ |

It only surfaced on EACRED supply because that RWA feed updates infrequently on chain, so it is essentially always stale (> 30s) and the `updatePythPriceFeeds` path is always taken. The state-level `price_info → Table` entry *is* a real dynamic object field, which is why `getPriceTableInfo()` succeeded and the failure only appeared at the per-feed lookup.

**Changes.**
- `getPriceFeedObjectId` (Core path) now uses `core.getDynamicField` with the plain `PriceIdentifier` name type and parses the `0x2::object::ID` value from its 32-byte BCS payload.
- The `price_info` table lookup keeps using `getDynamicObjectField` (correct for that entry).
- `getCoreProvider()` additionally requires `getDynamicField` (implemented on the same `CoreClient` base class as the other two methods, so client support is not narrowed).
- Legacy JSON-RPC path unchanged; prod behavior is identical.

## Test plan

- Updated the Core-provider test in `tests/pyth.test.ts`: table entries are mocked/asserted through `getDynamicField` with the exact name type and BCS bytes (`[0x20, ...feedId]`), the ID value returned as 32 raw BCS bytes, and exact call counts (`getDynamicObjectField` once for state `price_info` only, `getDynamicField` once for the table entry).
- `pnpm --filter @naviprotocol/lending test` — 54 passed, 0 failed.
- `tsc --noEmit` clean.
- Verified the corrected derivation against Sui mainnet: the plain-field ID `0xcc69e185...` resolves to the real `Field<PriceIdentifier, ID>` entry whose value is EACRED's `PriceInfoObject` `0x4309c8...`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes oracle price-update object resolution on the Core client path; incorrect lookups would break supplies that refresh Pyth feeds, though legacy RPC and the corrected on-chain derivation limit blast radius.
> 
> **Overview**
> Fixes **Pyth price feed updates** on the v2 **Core (gRPC)** client, which were failing with a bogus object ID because per-feed lookups used the wrong dynamic-field API.
> 
> On the Core path, `getPriceFeedObjectId` now resolves entries in Pyth’s price table via **`getDynamicField`** with a plain `PriceIdentifier` name and reads the **`0x2::object::ID`** from 32-byte BCS. The state-level **`price_info` → table** lookup still uses **`getDynamicObjectField`**. The legacy JSON-RPC path is unchanged. **`@naviprotocol/lending`** and **`@naviprotocol/wallet-client`** are bumped to **2.0.4**; Core provider tests assert the split between the two APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8965127f5f6145e08a1bb444a5a2e843ac872332. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->