### PR TITLE
Feat/pyth core upgrade endpoints

### DIFF
--- a/.changeset/pyth-price-table-plain-dynamic-field.md
+++ b/.changeset/pyth-price-table-plain-dynamic-field.md
@@ -1,0 +1,5 @@
+---
+'@naviprotocol/lending': patch
+---
+
+Fix Pyth price feed updates on the v2 Core (gRPC) client: price table entries are plain dynamic fields, so they are now fetched via `getDynamicField` instead of `getDynamicObjectField`, whose `Wrapper<PriceIdentifier>` derivation resolved to a nonexistent object and aborted every price refresh ("failed to update pyth price feeds, msg: Object 0x...").

--- a/packages/lending/src/oracle.ts
+++ b/packages/lending/src/oracle.ts
@@ -41,9 +41,16 @@ export type PythPriceInfo = {
  * Pyth Network connection for price feed data
  * Connects to the Hermes endpoint for real-time price updates
  */
-const suiPythConnection = new SuiPriceServiceConnection('https://hermes.pyth.network', {
-  timeout: 10000
-})
+const pythConnections = new Map<string, SuiPriceServiceConnection>()
+const getPythConnection = (endpoint?: string) => {
+  const url = endpoint ?? 'https://hermes.pyth.network'
+  let conn = pythConnections.get(url)
+  if (!conn) {
+    conn = new SuiPriceServiceConnection(url, { timeout: 10000 })
+    pythConnections.set(url, conn)
+  }
+  return conn
+}
 
 /**
  * Get stale price feed IDs from Pyth Network
@@ -55,10 +62,16 @@ const suiPythConnection = new SuiPriceServiceConnection('https://hermes.pyth.net
  * @returns Array of stale price feed IDs that need updating
  * @throws Error if failed to fetch price feed data
  */
-export async function getPythStalePriceFeedId(priceIds: string[]): Promise<string[]> {
+export async function getPythStalePriceFeedId(
+  priceIds: string[],
+  options?: Partial<EnvOption & MarketOption>
+): Promise<string[]> {
   try {
     const returnData: string[] = []
-    const latestPriceFeeds = await suiPythConnection.getLatestPriceFeeds(priceIds)
+    const config = await getConfig({ ...options, cacheTime: DEFAULT_CACHE_TIME })
+    const latestPriceFeeds = await getPythConnection(
+      config.oracle.hermesEndpoint
+    ).getLatestPriceFeeds(priceIds)
     if (!latestPriceFeeds) return returnData
 
     const currentTimestamp = Math.floor(new Date().valueOf() / 1000)
@@ -200,7 +213,9 @@ export async function updatePythPriceFeeds(
     cacheTime: DEFAULT_CACHE_TIME
   })
   try {
-    const priceUpdateData = await suiPythConnection.getPriceFeedsUpdateData(priceFeedIds)
+    const priceUpdateData = await getPythConnection(
+      config.oracle.hermesEndpoint
+    ).getPriceFeedsUpdateData(priceFeedIds)
     const suiPythClient = new SuiPythClient(
       client as any,
       config.oracle.pythStateId,
@@ -265,7 +280,7 @@ export async function updateOraclePricesPTB(
   // Update individual price feeds in the oracle contract
   for (const priceFeed of priceFeeds) {
     tx.moveCall({
-      target: `${config.oracle.packageId}::oracle_pro::update_single_price_v2`,
+      target: `${config.oracle.packageId}::oracle_pro::${config.oracle.updateFunction ?? 'update_single_price_v2'}`,
       arguments: [
         tx.object('0x6'), // Clock object
         tx.object(config.oracle.oracleConfig), // Oracle configuration

--- a/packages/lending/src/pyth.ts
+++ b/packages/lending/src/pyth.ts
@@ -55,6 +55,9 @@ type SuiPythCoreProvider = {
   }): Promise<{
     object?: { objectId: string; type?: string; json?: Record<string, unknown> | null }
   }>
+  getDynamicField(options: { parentId: string; name: CoreDynamicFieldName }): Promise<{
+    dynamicField?: { value?: { type?: string; bcs?: Uint8Array } }
+  }>
 }
 
 const MAX_ARGUMENT_SIZE = 16 * 1024
@@ -248,7 +251,8 @@ export class SuiPythClient {
     if (
       core &&
       typeof core.getObject === 'function' &&
-      typeof core.getDynamicObjectField === 'function'
+      typeof core.getDynamicObjectField === 'function' &&
+      typeof core.getDynamicField === 'function'
     ) {
       return core as SuiPythCoreProvider
     }
@@ -465,22 +469,38 @@ export class SuiPythClient {
     const normalizedFeedId = normalizePriceId(feedId)
     if (!this.priceFeedObjectIdCache.has(normalizedFeedId)) {
       const { id: tableId, fieldType } = await this.getPriceTableInfo()
-      const fieldName = this.getCoreProvider()
-        ? toDynamicFieldName(
-            `${fieldType}::price_identifier::PriceIdentifier`,
-            encodePriceIdentifier(hexToBytes(normalizedFeedId))
-          )
-        : {
-            type: `${fieldType}::price_identifier::PriceIdentifier`,
-            value: {
-              bytes: Array.from(hexToBytes(normalizedFeedId))
-            }
-          }
-      const result = await this.getDynamicMoveObjectJson(tableId, fieldName)
-      if (!result?.fields) {
-        this.priceFeedObjectIdCache.set(normalizedFeedId, undefined)
+      const nameType = `${fieldType}::price_identifier::PriceIdentifier`
+
+      const core = this.getCoreProvider()
+      if (core) {
+        // Pyth's price table stores entries as plain dynamic fields
+        // (0x2::dynamic_field::Field<PriceIdentifier, ID>). getDynamicObjectField
+        // must not be used here: it derives the child id from
+        // Wrapper<PriceIdentifier> and resolves to an object that does not exist
+        // on chain, aborting every Pyth price feed update.
+        const { dynamicField } = await core.getDynamicField({
+          parentId: tableId,
+          name: toDynamicFieldName(nameType, encodePriceIdentifier(hexToBytes(normalizedFeedId)))
+        })
+        const valueBcs = dynamicField?.value?.bcs
+        this.priceFeedObjectIdCache.set(
+          normalizedFeedId,
+          valueBcs && valueBcs.length === 32
+            ? bcs.Address.parse(Uint8Array.from(valueBcs))
+            : undefined
+        )
       } else {
-        this.priceFeedObjectIdCache.set(normalizedFeedId, (result.fields as any).value)
+        const result = await this.getDynamicMoveObjectJson(tableId, {
+          type: nameType,
+          value: {
+            bytes: Array.from(hexToBytes(normalizedFeedId))
+          }
+        })
+        if (!result?.fields) {
+          this.priceFeedObjectIdCache.set(normalizedFeedId, undefined)
+        } else {
+          this.priceFeedObjectIdCache.set(normalizedFeedId, (result.fields as any).value)
+        }
       }
     }
     return this.priceFeedObjectIdCache.get(normalizedFeedId)

--- a/packages/lending/src/types.ts
+++ b/packages/lending/src/types.ts
@@ -502,6 +502,10 @@ export type LendingConfig = {
   oracle: {
     /** Package ID */
     packageId: string
+    /** Oracle price-update entry function (defaults to update_single_price_v2; upgraded envs use update_single_price_v3) */
+    updateFunction?: string
+    /** Hermes endpoint for this env (defaults to legacy hermes.pyth.network; upgraded envs use the open-api proxy) */
+    hermesEndpoint?: string
     /** Price oracle contract address */
     priceOracle: string
     /** Oracle admin capability ID */

--- a/packages/lending/tests/pyth.test.ts
+++ b/packages/lending/tests/pyth.test.ts
@@ -284,13 +284,28 @@ describe('SuiPythClient', () => {
               }
             }
 
+            throw new Error(`unexpected dynamic object field parent ${parentId}`)
+          }
+        ),
+        getDynamicField: vi.fn(
+          async ({
+            parentId,
+            name
+          }: {
+            parentId: string
+            name: { type: string; bcs: Uint8Array }
+          }) => {
             if (parentId === priceTableId) {
               expect(name.type).toBe(`${pythPackageId}::price_identifier::PriceIdentifier`)
+              expect(Array.from(name.bcs)).toEqual([
+                0x20,
+                ...Array.from(Uint8Array.from({ length: 32 }, () => 0xbb))
+              ])
               return {
-                object: {
-                  objectId: priceInfoObjectId,
-                  json: {
-                    value: priceInfoObjectId
+                dynamicField: {
+                  value: {
+                    type: `${normalizedSystemPackage}::object::ID`,
+                    bcs: Uint8Array.from({ length: 32 }, () => 0x66)
                   }
                 }
               }
@@ -317,5 +332,11 @@ describe('SuiPythClient', () => {
       objectId: wormholeStateId,
       include: { json: true }
     })
+    // The state's `price_info` entry is a dynamic object field, but the price
+    // table entries are plain dynamic fields: fetching them through
+    // getDynamicObjectField derives a Wrapper<PriceIdentifier> child id that
+    // does not exist on chain.
+    expect(provider.core.getDynamicObjectField).toHaveBeenCalledTimes(1)
+    expect(provider.core.getDynamicField).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION

## Why

Pyth Core cutover is **July 31**: the legacy Hermes endpoint redirects to an
authenticated one, and envs whose oracle package is upgraded to the pyth
pro-compatible contract must call `update_single_price_v3` (the old `v2`
entry aborts after `version_migrate`). The API key cannot ship in the
frontend, so upgraded envs fetch price data through the open-api
`pyth-hermes-proxy` route (key injected server-side, CDN-cached).

## What

- `oracle.ts`: module-level `SuiPriceServiceConnection` singleton replaced by a
  per-endpoint factory; `updatePythPriceFeeds` / `getPythStalePriceFeedId`
  use `config.oracle.hermesEndpoint`
- `oracle.ts`: price-update target is `config.oracle.updateFunction`
- `types.ts`: optional `oracle.updateFunction` / `oracle.hermesEndpoint`

## Behavior / risk

- **No behavior change by default**: both fields are optional; without them the
  SDK keeps `https://hermes.pyth.network` + `update_single_price_v2` (current
  prod). Config comes from open-api `/navi/config`, so the prod cutover later
  is a config flip — no SDK release needed.
- dev env config (see companion PR) already sets both fields.

## Verified

- End-to-end on the upgraded stage_v2 env: 37/37 feeds updated through
  proxy -> upgraded Pyth -> `update_single_price_v3`, no client-side key.
- Full dress rehearsal of the upgrade path (v2 legacy push -> real package
  upgrade -> v3 push, 37/37 both sides) done on a mainnet throwaway deployment.
- `tsc --noEmit` clean.

Companion PR: navi-open-api `feat/dev-pyth-oracle-config`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes oracle/Pyth price refresh and on-chain update entrypoints; defaults preserve current prod, but misconfigured endpoints or update functions would break lending price updates.
> 
> **Overview**
> Prepares the lending SDK for **Pyth Core cutover** and fixes **broken price refreshes** on the v2 Core (gRPC) client.
> 
> **Hermes & oracle entrypoints** are now driven by optional config: a per-URL cached `SuiPriceServiceConnection` replaces the single Hermes singleton; stale checks and PTB updates use `config.oracle.hermesEndpoint`, and on-chain oracle updates call `config.oracle.updateFunction` (default **`update_single_price_v2`**). Without those fields, behavior stays on legacy Hermes + v2.
> 
> On Core, **Pyth price table rows** are plain `dynamic_field` entries (`Field<PriceIdentifier, ID>`), not child objects. Lookup now uses **`getDynamicField`** and parses the stored object ID from BCS instead of **`getDynamicObjectField`**, which derived a nonexistent `Wrapper<PriceIdentifier>` object and aborted every feed update with “Object 0x…”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 386987d37c1026a80221c7fe7a68498c120fd489. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->