### PR TITLE
fix(build): NodeNext moduleResolution compatibility

### DIFF
--- a/config/check-sdk-v2-boundaries.mjs
+++ b/config/check-sdk-v2-boundaries.mjs
@@ -146,7 +146,7 @@ for (const packageName of sdkPackages) {
     }
 
     const isJsFile = normalizedFile.endsWith('.js')
-    if (isJsFile && /\brequire\s*\(/.test(content)) {
+    if (isJsFile && !isBridgeMayanArtifact && /\brequire\s*\(/.test(content)) {
       issues.push(`${relativeFile}: ESM bundle contains require()`)
     }
 

--- a/config/check-sdk-v2-boundaries.mjs
+++ b/config/check-sdk-v2-boundaries.mjs
@@ -66,7 +66,7 @@ function listFiles(dir) {
 
 function assertRequiredDistFiles(packageName, distFiles) {
   const normalizedFiles = new Set(distFiles.map(toPosixPath))
-  for (const requiredFile of ['index.esm.js', 'index.d.ts']) {
+  for (const requiredFile of ['index.js', 'index.d.ts']) {
     if (!normalizedFiles.has(requiredFile)) {
       issues.push(`${packageName}: dist/${requiredFile} is missing; run build before boundary scan`)
     }
@@ -128,7 +128,7 @@ for (const packageName of sdkPackages) {
     const relativeFile = path.relative(repoRoot, absoluteFile)
     const content = fs.readFileSync(absoluteFile, 'utf8')
     const isDeclaration = normalizedFile.endsWith('.d.ts')
-    const isRootBundle = normalizedFile === 'index.esm.js'
+    const isRootBundle = normalizedFile === 'index.js'
     const isBridgeMayanArtifact =
       packageName === 'astros-bridge-sdk' &&
       (normalizedFile.startsWith('mayan-') || normalizedFile.startsWith('providers/mayan'))

--- a/config/check-sdk-v2-boundaries.mjs
+++ b/config/check-sdk-v2-boundaries.mjs
@@ -131,7 +131,7 @@ for (const packageName of sdkPackages) {
     const isRootBundle = normalizedFile === 'index.js'
     const isBridgeMayanArtifact =
       packageName === 'astros-bridge-sdk' &&
-      (normalizedFile.startsWith('mayan-') || normalizedFile.startsWith('providers/mayan'))
+      (normalizedFile.startsWith('mayan') || normalizedFile.startsWith('providers/mayan'))
     const isWalletSuilendArtifact =
       packageName === 'wallet-client' &&
       (normalizedFile.startsWith('suilend-') ||
@@ -145,8 +145,9 @@ for (const packageName of sdkPackages) {
       }
     }
 
-    if (isRootBundle && /\brequire\s*\(/.test(content)) {
-      issues.push(`${relativeFile}: root ESM bundle contains require()`)
+    const isJsFile = normalizedFile.endsWith('.js')
+    if (isJsFile && /\brequire\s*\(/.test(content)) {
+      issues.push(`${relativeFile}: ESM bundle contains require()`)
     }
 
     if (!isBridgeMayanArtifact && content.includes('@mayanfinance')) {

--- a/config/check-sdk-v2-boundaries.mjs
+++ b/config/check-sdk-v2-boundaries.mjs
@@ -128,7 +128,6 @@ for (const packageName of sdkPackages) {
     const relativeFile = path.relative(repoRoot, absoluteFile)
     const content = fs.readFileSync(absoluteFile, 'utf8')
     const isDeclaration = normalizedFile.endsWith('.d.ts')
-    const isRootBundle = normalizedFile === 'index.js'
     const isBridgeMayanArtifact =
       packageName === 'astros-bridge-sdk' &&
       (normalizedFile.startsWith('mayan') || normalizedFile.startsWith('providers/mayan'))

--- a/config/vite.lib.config.js
+++ b/config/vite.lib.config.js
@@ -13,6 +13,26 @@ const entry = fs.existsSync(tsEntry) ? tsEntry : tsEntry.replace('.ts', '.tsx')
 
 const deps = [...Object.keys(Object.assign({}, pkg.peerDependencies, pkg.dependencies))]
 
+function addJsExtensionsToDts(dir) {
+  const files = fs.readdirSync(dir)
+  for (const file of files) {
+    const filePath = path.join(dir, file)
+    const stat = fs.statSync(filePath)
+    if (stat.isDirectory()) {
+      addJsExtensionsToDts(filePath)
+    } else if (file.endsWith('.d.ts') && !file.endsWith('.d.ts.map')) {
+      let content = fs.readFileSync(filePath, 'utf8')
+      // Add .js extension to relative imports/exports that don't have an extension
+      content = content.replace(/(from\s+['"])(\.\.?\/[^'"]+?)(?<!\.js)(['"])/g, '$1$2.js$3')
+      content = content.replace(
+        /(export\s+\*\s+from\s+['"])(\.\.?\/[^'"]+?)(?<!\.js)(['"])/g,
+        '$1$2.js$3'
+      )
+      fs.writeFileSync(filePath, content)
+    }
+  }
+}
+
 export default defineConfig({
   plugins: [
     tsconfigPaths(),
@@ -22,7 +42,10 @@ export default defineConfig({
       // Was defaulting to true until version 1.7
       skipDiagnostics: true,
       // Was defaulting to true until version 2.0
-      copyDtsFiles: true
+      copyDtsFiles: true,
+      afterBuild: () => {
+        addJsExtensionsToDts(path.join(PWD, 'dist'))
+      }
     })
   ],
   test: {
@@ -41,7 +64,6 @@ export default defineConfig({
     lib: {
       entry,
       name: pkg.name,
-      fileName: () => `index.esm.js`,
       formats: ['es']
     },
     rollupOptions: {
@@ -53,7 +75,9 @@ export default defineConfig({
         })
       ],
       output: {
-        globals: {}
+        preserveModules: true,
+        preserveModulesRoot: 'src',
+        entryFileNames: '[name].js'
       }
     }
   }

--- a/config/vite.lib.config.js
+++ b/config/vite.lib.config.js
@@ -13,24 +13,95 @@ const entry = fs.existsSync(tsEntry) ? tsEntry : tsEntry.replace('.ts', '.tsx')
 
 const deps = [...Object.keys(Object.assign({}, pkg.peerDependencies, pkg.dependencies))]
 
-function addJsExtensionsToDts(dir) {
-  const files = fs.readdirSync(dir)
-  for (const file of files) {
-    const filePath = path.join(dir, file)
-    const stat = fs.statSync(filePath)
-    if (stat.isDirectory()) {
-      addJsExtensionsToDts(filePath)
-    } else if (file.endsWith('.d.ts') && !file.endsWith('.d.ts.map')) {
-      let content = fs.readFileSync(filePath, 'utf8')
-      // Add .js extension to relative imports/exports that don't have an extension
-      content = content.replace(/(from\s+['"])(\.\.?\/[^'"]+?)(?<!\.js)(['"])/g, '$1$2.js$3')
-      content = content.replace(
-        /(export\s+\*\s+from\s+['"])(\.\.?\/[^'"]+?)(?<!\.js)(['"])/g,
-        '$1$2.js$3'
-      )
+function addJsExtensionsToDts(distDir) {
+  const rewriteSpecifier = (specifier, fromFile) => {
+    // Already has .js extension
+    if (specifier.endsWith('.js')) return specifier
+    // Has other extension (e.g., .json, .css)
+    if (/\.\w+$/.test(specifier)) return specifier
+
+    // Resolve the specifier relative to the file's directory
+    const fromDir = path.dirname(fromFile)
+    const resolved = path.resolve(fromDir, specifier)
+
+    // Check if it's a directory (barrel import)
+    if (fs.existsSync(resolved) && fs.statSync(resolved).isDirectory()) {
+      return specifier + '/index.js'
+    }
+    // Otherwise it's a file
+    return specifier + '.js'
+  }
+
+  const processFile = (filePath) => {
+    let content = fs.readFileSync(filePath, 'utf8')
+    let modified = false
+
+    // Match: from './path' or from "../path"
+    content = content.replace(
+      /(from\s+['"])(\.\.?\/[^'"]+?)(['"])/g,
+      (match, prefix, specifier, suffix) => {
+        const newSpecifier = rewriteSpecifier(specifier, filePath)
+        if (newSpecifier !== specifier) modified = true
+        return prefix + newSpecifier + suffix
+      }
+    )
+
+    // Match: export * from './path'
+    content = content.replace(
+      /(export\s+\*\s+from\s+['"])(\.\.?\/[^'"]+?)(['"])/g,
+      (match, prefix, specifier, suffix) => {
+        const newSpecifier = rewriteSpecifier(specifier, filePath)
+        if (newSpecifier !== specifier) modified = true
+        return prefix + newSpecifier + suffix
+      }
+    )
+
+    if (modified) {
       fs.writeFileSync(filePath, content)
     }
   }
+
+  const walk = (dir) => {
+    for (const file of fs.readdirSync(dir)) {
+      const filePath = path.join(dir, file)
+      const stat = fs.statSync(filePath)
+      if (stat.isDirectory()) {
+        walk(filePath)
+      } else if (file.endsWith('.d.ts') && !file.endsWith('.d.ts.map')) {
+        processFile(filePath)
+      }
+    }
+  }
+
+  walk(distDir)
+}
+
+function generateMissingBarrelJs(distDir) {
+  const walk = (dir) => {
+    for (const file of fs.readdirSync(dir)) {
+      const filePath = path.join(dir, file)
+      const stat = fs.statSync(filePath)
+      if (stat.isDirectory()) {
+        walk(filePath)
+      } else if (file === 'index.d.ts') {
+        const jsFile = path.join(dir, 'index.js')
+        if (!fs.existsSync(jsFile)) {
+          // Parse the .d.ts to extract re-exports and generate matching JS
+          const dtsContent = fs.readFileSync(filePath, 'utf8')
+          const exports = []
+          const reExportRegex = /export\s+\*\s+from\s+['"]([^'"]+)['"]/g
+          let match
+          while ((match = reExportRegex.exec(dtsContent)) !== null) {
+            exports.push(`export * from '${match[1]}';`)
+          }
+          if (exports.length > 0) {
+            fs.writeFileSync(jsFile, exports.join('\n') + '\n')
+          }
+        }
+      }
+    }
+  }
+  walk(distDir)
 }
 
 export default defineConfig({
@@ -44,7 +115,9 @@ export default defineConfig({
       // Was defaulting to true until version 2.0
       copyDtsFiles: true,
       afterBuild: () => {
-        addJsExtensionsToDts(path.join(PWD, 'dist'))
+        const distDir = path.join(PWD, 'dist')
+        addJsExtensionsToDts(distDir)
+        generateMissingBarrelJs(distDir)
       }
     })
   ],

--- a/config/vite.lib.config.js
+++ b/config/vite.lib.config.js
@@ -89,11 +89,26 @@ function generateMissingBarrelJs(distDir) {
           // Parse the .d.ts to extract re-exports and generate matching JS
           const dtsContent = fs.readFileSync(filePath, 'utf8')
           const exports = []
-          const reExportRegex = /export\s+\*\s+from\s+['"]([^'"]+)['"]/g
+
+          // Match: export * from '...'
+          const starReExportRegex = /export\s+\*\s+from\s+['"]([^'"]+)['"]/g
           let match
-          while ((match = reExportRegex.exec(dtsContent)) !== null) {
+          while ((match = starReExportRegex.exec(dtsContent)) !== null) {
             exports.push(`export * from '${match[1]}';`)
           }
+
+          // Match: export { foo, bar } from '...'
+          const namedReExportRegex = /export\s+\{([^}]+)\}\s+from\s+['"]([^'"]+)['"]/g
+          while ((match = namedReExportRegex.exec(dtsContent)) !== null) {
+            const names = match[1]
+              .split(',')
+              .map((n) => n.trim())
+              .filter((n) => n && !n.startsWith('type '))
+            if (names.length > 0) {
+              exports.push(`export { ${names.join(', ')} } from '${match[2]}';`)
+            }
+          }
+
           if (exports.length > 0) {
             fs.writeFileSync(jsFile, exports.join('\n') + '\n')
           }

--- a/packages/astros-aggregator-sdk/package.json
+++ b/packages/astros-aggregator-sdk/package.json
@@ -17,8 +17,8 @@
     "type": "git",
     "url": "https://github.com/naviprotocol/naviprotocol-monorepo.git"
   },
-  "main": "dist/index.esm.js",
-  "module": "dist/index.esm.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "files": [
@@ -29,8 +29,8 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.esm.js",
-      "default": "./dist/index.esm.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   },
   "publishConfig": {

--- a/packages/astros-bridge-sdk/package.json
+++ b/packages/astros-bridge-sdk/package.json
@@ -17,8 +17,8 @@
     "type": "git",
     "url": "https://github.com/naviprotocol/naviprotocol-monorepo.git"
   },
-  "main": "dist/index.esm.js",
-  "module": "dist/index.esm.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "files": [
@@ -29,8 +29,8 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.esm.js",
-      "default": "./dist/index.esm.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   },
   "publishConfig": {

--- a/packages/astros-bridge-sdk/vite.config.js
+++ b/packages/astros-bridge-sdk/vite.config.js
@@ -27,7 +27,13 @@ export default defineConfig({
     rollupOptions: {
       ...baseConfig.build?.rollupOptions,
       external: bridgeExternal,
-      plugins: [...(baseConfig.build?.rollupOptions?.plugins || [])]
+      plugins: [...(baseConfig.build?.rollupOptions?.plugins || [])],
+      output: {
+        // Disable preserveModules to keep lazy-loading chunks for Mayan SDK
+        preserveModules: false,
+        entryFileNames: 'index.js',
+        chunkFileNames: '[name].js'
+      }
     }
   }
 })

--- a/packages/astros-dca-sdk/package.json
+++ b/packages/astros-dca-sdk/package.json
@@ -17,8 +17,8 @@
     "type": "git",
     "url": "https://github.com/naviprotocol/naviprotocol-monorepo.git"
   },
-  "main": "dist/index.esm.js",
-  "module": "dist/index.esm.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "files": [
@@ -29,8 +29,8 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.esm.js",
-      "default": "./dist/index.esm.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   },
   "publishConfig": {

--- a/packages/lending/package.json
+++ b/packages/lending/package.json
@@ -16,8 +16,8 @@
     "type": "git",
     "url": "https://github.com/naviprotocol/naviprotocol-monorepo.git"
   },
-  "main": "dist/index.esm.js",
-  "module": "dist/index.esm.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "files": [
@@ -28,8 +28,8 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.esm.js",
-      "default": "./dist/index.esm.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   },
   "publishConfig": {

--- a/packages/wallet-client/package.json
+++ b/packages/wallet-client/package.json
@@ -15,8 +15,8 @@
     "type": "git",
     "url": "https://github.com/naviprotocol/naviprotocol-monorepo.git"
   },
-  "main": "dist/index.esm.js",
-  "module": "dist/index.esm.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "files": [
@@ -27,8 +27,8 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.esm.js",
-      "default": "./dist/index.esm.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   },
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -535,12 +535,20 @@ packages:
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.27.1':
     resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.27.1':
@@ -562,6 +570,11 @@ packages:
 
   '@babel/parser@7.28.5':
     resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1125,6 +1138,10 @@ packages:
 
   '@babel/types@7.28.5':
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@1.0.2':
@@ -3164,11 +3181,11 @@ packages:
   '@volar/typescript@1.11.1':
     resolution: {integrity: sha512-iU+t2mas/4lYierSnoFOeRFQUhAEMgsFuQxoxvwn5EdQopw43j+J27a4lt9LMInx1gLJBC6qL14WYGlgymaSMQ==}
 
-  '@vue/compiler-core@3.5.21':
-    resolution: {integrity: sha512-8i+LZ0vf6ZgII5Z9XmUvrCyEzocvWT+TeR2VBUVlzIH6Tyv57E20mPZ1bCS+tbejgUgmjrEh7q/0F0bibskAmw==}
+  '@vue/compiler-core@3.5.40':
+    resolution: {integrity: sha512-39E8IgOhTbVDnoJFMKc2DvYnypcZwUqgUhQkccva/0m6FUwtIKSGV7n1hpVmYcFaoRAwf9pBcwnKlCEsN63ZEQ==}
 
-  '@vue/compiler-dom@3.5.21':
-    resolution: {integrity: sha512-jNtbu/u97wiyEBJlJ9kmdw7tAr5Vy0Aj5CgQmo+6pxWNQhXZDPsRr1UWPN4v3Zf82s2H3kF51IbzZ4jMWAgPlQ==}
+  '@vue/compiler-dom@3.5.40':
+    resolution: {integrity: sha512-pwkx4vqlqOspFstrcmzwkKLePVMD3PT65imRzLhanU2V1Fj4K13g6OXjanOyzw3aTAuRk84BOmY8f3rEHqPaVA==}
 
   '@vue/language-core@1.8.27':
     resolution: {integrity: sha512-L8Kc27VdQserNaCUNiSFdDl9LWT24ly8Hpwf1ECy3aFb9m6bDhBGQYOujDm21N7EW3moKIOKEanQwe1q5BK+mA==}
@@ -3178,8 +3195,8 @@ packages:
       typescript:
         optional: true
 
-  '@vue/shared@3.5.21':
-    resolution: {integrity: sha512-+2k1EQpnYuVuu3N7atWyG3/xoFWIVJZq4Mz8XNOdScFI0etES75fbny/oU4lKWk/577P1zmg0ioYvpGEDZ3DLw==}
+  '@vue/shared@3.5.40':
+    resolution: {integrity: sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg==}
 
   '@wallet-standard/app@1.1.0':
     resolution: {integrity: sha512-3CijvrO9utx598kjr45hTbbeeykQrQfKmSnxeWOgU25TOEpvcipD/bYDQWIqUv1Oc6KK4YStokSMu/FBNecGUQ==}
@@ -3969,6 +3986,10 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
@@ -4554,7 +4575,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    deprecated: Glob versions prior to v9 are no longer supported
 
   globals@13.24.0:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
@@ -6667,8 +6688,8 @@ packages:
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
-  validator@13.15.15:
-    resolution: {integrity: sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==}
+  validator@13.15.35:
+    resolution: {integrity: sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==}
     engines: {node: '>= 0.10'}
 
   vfile-message@4.0.3:
@@ -7126,9 +7147,13 @@ snapshots:
 
   '@babel/helper-string-parser@7.27.1': {}
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-validator-identifier@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/helper-validator-option@7.27.1': {}
 
@@ -7152,6 +7177,10 @@ snapshots:
   '@babel/parser@7.28.5':
     dependencies:
       '@babel/types': 7.28.5
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
 
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.27.1(@babel/core@7.26.10)':
     dependencies:
@@ -7856,6 +7885,11 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@bcoe/v8-coverage@1.0.2': {}
 
@@ -9742,7 +9776,7 @@ snapshots:
       debug: 4.4.3
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.7.2
+      semver: 7.7.3
       tsutils: 3.21.0(typescript@5.8.3)
     optionalDependencies:
       typescript: 5.8.3
@@ -9759,7 +9793,7 @@ snapshots:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.8.3)
       eslint: 8.57.0
       eslint-scope: 5.1.1
-      semver: 7.7.2
+      semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -9922,25 +9956,25 @@ snapshots:
       '@volar/language-core': 1.11.1
       path-browserify: 1.0.1
 
-  '@vue/compiler-core@3.5.21':
+  '@vue/compiler-core@3.5.40':
     dependencies:
-      '@babel/parser': 7.28.4
-      '@vue/shared': 3.5.21
-      entities: 4.5.0
+      '@babel/parser': 7.29.7
+      '@vue/shared': 3.5.40
+      entities: 7.0.1
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
-  '@vue/compiler-dom@3.5.21':
+  '@vue/compiler-dom@3.5.40':
     dependencies:
-      '@vue/compiler-core': 3.5.21
-      '@vue/shared': 3.5.21
+      '@vue/compiler-core': 3.5.40
+      '@vue/shared': 3.5.40
 
   '@vue/language-core@1.8.27(typescript@5.8.3)':
     dependencies:
       '@volar/language-core': 1.11.1
       '@volar/source-map': 1.11.1
-      '@vue/compiler-dom': 3.5.21
-      '@vue/shared': 3.5.21
+      '@vue/compiler-dom': 3.5.40
+      '@vue/shared': 3.5.40
       computeds: 0.0.1
       minimatch: 9.0.5
       muggle-string: 0.3.1
@@ -9949,7 +9983,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
-  '@vue/shared@3.5.21': {}
+  '@vue/shared@3.5.40': {}
 
   '@wallet-standard/app@1.1.0':
     dependencies:
@@ -10790,6 +10824,8 @@ snapshots:
   entities@4.5.0: {}
 
   entities@6.0.1: {}
+
+  entities@7.0.1: {}
 
   error-ex@1.3.4:
     dependencies:
@@ -14219,7 +14255,7 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
-  validator@13.15.15: {}
+  validator@13.15.35: {}
 
   vfile-message@4.0.3:
     dependencies:
@@ -14336,7 +14372,7 @@ snapshots:
       espree: 9.6.1
       esquery: 1.6.0
       lodash: 4.17.21
-      semver: 7.7.2
+      semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
 
@@ -14349,7 +14385,7 @@ snapshots:
     dependencies:
       '@volar/typescript': 1.11.1
       '@vue/language-core': 1.8.27(typescript@5.8.3)
-      semver: 7.7.2
+      semver: 7.7.3
       typescript: 5.8.3
 
   w3c-xmlserializer@5.0.0:
@@ -14499,7 +14535,7 @@ snapshots:
     dependencies:
       lodash.get: 4.4.2
       lodash.isequal: 4.5.0
-      validator: 13.15.15
+      validator: 13.15.35
     optionalDependencies:
       commander: 9.5.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -535,20 +535,12 @@ packages:
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.29.7':
-    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-validator-identifier@7.27.1':
     resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.29.7':
-    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.27.1':
@@ -570,11 +562,6 @@ packages:
 
   '@babel/parser@7.28.5':
     resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  '@babel/parser@7.29.7':
-    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1138,10 +1125,6 @@ packages:
 
   '@babel/types@7.28.5':
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.29.7':
-    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@1.0.2':
@@ -3181,11 +3164,11 @@ packages:
   '@volar/typescript@1.11.1':
     resolution: {integrity: sha512-iU+t2mas/4lYierSnoFOeRFQUhAEMgsFuQxoxvwn5EdQopw43j+J27a4lt9LMInx1gLJBC6qL14WYGlgymaSMQ==}
 
-  '@vue/compiler-core@3.5.40':
-    resolution: {integrity: sha512-39E8IgOhTbVDnoJFMKc2DvYnypcZwUqgUhQkccva/0m6FUwtIKSGV7n1hpVmYcFaoRAwf9pBcwnKlCEsN63ZEQ==}
+  '@vue/compiler-core@3.5.21':
+    resolution: {integrity: sha512-8i+LZ0vf6ZgII5Z9XmUvrCyEzocvWT+TeR2VBUVlzIH6Tyv57E20mPZ1bCS+tbejgUgmjrEh7q/0F0bibskAmw==}
 
-  '@vue/compiler-dom@3.5.40':
-    resolution: {integrity: sha512-pwkx4vqlqOspFstrcmzwkKLePVMD3PT65imRzLhanU2V1Fj4K13g6OXjanOyzw3aTAuRk84BOmY8f3rEHqPaVA==}
+  '@vue/compiler-dom@3.5.21':
+    resolution: {integrity: sha512-jNtbu/u97wiyEBJlJ9kmdw7tAr5Vy0Aj5CgQmo+6pxWNQhXZDPsRr1UWPN4v3Zf82s2H3kF51IbzZ4jMWAgPlQ==}
 
   '@vue/language-core@1.8.27':
     resolution: {integrity: sha512-L8Kc27VdQserNaCUNiSFdDl9LWT24ly8Hpwf1ECy3aFb9m6bDhBGQYOujDm21N7EW3moKIOKEanQwe1q5BK+mA==}
@@ -3195,8 +3178,8 @@ packages:
       typescript:
         optional: true
 
-  '@vue/shared@3.5.40':
-    resolution: {integrity: sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg==}
+  '@vue/shared@3.5.21':
+    resolution: {integrity: sha512-+2k1EQpnYuVuu3N7atWyG3/xoFWIVJZq4Mz8XNOdScFI0etES75fbny/oU4lKWk/577P1zmg0ioYvpGEDZ3DLw==}
 
   '@wallet-standard/app@1.1.0':
     resolution: {integrity: sha512-3CijvrO9utx598kjr45hTbbeeykQrQfKmSnxeWOgU25TOEpvcipD/bYDQWIqUv1Oc6KK4YStokSMu/FBNecGUQ==}
@@ -3986,10 +3969,6 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
-  entities@7.0.1:
-    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
-    engines: {node: '>=0.12'}
-
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
@@ -4575,7 +4554,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@13.24.0:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
@@ -6688,8 +6667,8 @@ packages:
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
-  validator@13.15.35:
-    resolution: {integrity: sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==}
+  validator@13.15.15:
+    resolution: {integrity: sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==}
     engines: {node: '>= 0.10'}
 
   vfile-message@4.0.3:
@@ -7147,13 +7126,9 @@ snapshots:
 
   '@babel/helper-string-parser@7.27.1': {}
 
-  '@babel/helper-string-parser@7.29.7': {}
-
   '@babel/helper-validator-identifier@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
-
-  '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/helper-validator-option@7.27.1': {}
 
@@ -7177,10 +7152,6 @@ snapshots:
   '@babel/parser@7.28.5':
     dependencies:
       '@babel/types': 7.28.5
-
-  '@babel/parser@7.29.7':
-    dependencies:
-      '@babel/types': 7.29.7
 
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.27.1(@babel/core@7.26.10)':
     dependencies:
@@ -7885,11 +7856,6 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
-
-  '@babel/types@7.29.7':
-    dependencies:
-      '@babel/helper-string-parser': 7.29.7
-      '@babel/helper-validator-identifier': 7.29.7
 
   '@bcoe/v8-coverage@1.0.2': {}
 
@@ -9776,7 +9742,7 @@ snapshots:
       debug: 4.4.3
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.7.3
+      semver: 7.7.2
       tsutils: 3.21.0(typescript@5.8.3)
     optionalDependencies:
       typescript: 5.8.3
@@ -9793,7 +9759,7 @@ snapshots:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.8.3)
       eslint: 8.57.0
       eslint-scope: 5.1.1
-      semver: 7.7.3
+      semver: 7.7.2
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -9956,25 +9922,25 @@ snapshots:
       '@volar/language-core': 1.11.1
       path-browserify: 1.0.1
 
-  '@vue/compiler-core@3.5.40':
+  '@vue/compiler-core@3.5.21':
     dependencies:
-      '@babel/parser': 7.29.7
-      '@vue/shared': 3.5.40
-      entities: 7.0.1
+      '@babel/parser': 7.28.4
+      '@vue/shared': 3.5.21
+      entities: 4.5.0
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
-  '@vue/compiler-dom@3.5.40':
+  '@vue/compiler-dom@3.5.21':
     dependencies:
-      '@vue/compiler-core': 3.5.40
-      '@vue/shared': 3.5.40
+      '@vue/compiler-core': 3.5.21
+      '@vue/shared': 3.5.21
 
   '@vue/language-core@1.8.27(typescript@5.8.3)':
     dependencies:
       '@volar/language-core': 1.11.1
       '@volar/source-map': 1.11.1
-      '@vue/compiler-dom': 3.5.40
-      '@vue/shared': 3.5.40
+      '@vue/compiler-dom': 3.5.21
+      '@vue/shared': 3.5.21
       computeds: 0.0.1
       minimatch: 9.0.5
       muggle-string: 0.3.1
@@ -9983,7 +9949,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
-  '@vue/shared@3.5.40': {}
+  '@vue/shared@3.5.21': {}
 
   '@wallet-standard/app@1.1.0':
     dependencies:
@@ -10824,8 +10790,6 @@ snapshots:
   entities@4.5.0: {}
 
   entities@6.0.1: {}
-
-  entities@7.0.1: {}
 
   error-ex@1.3.4:
     dependencies:
@@ -14255,7 +14219,7 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
-  validator@13.15.35: {}
+  validator@13.15.15: {}
 
   vfile-message@4.0.3:
     dependencies:
@@ -14372,7 +14336,7 @@ snapshots:
       espree: 9.6.1
       esquery: 1.6.0
       lodash: 4.17.21
-      semver: 7.7.3
+      semver: 7.7.2
     transitivePeerDependencies:
       - supports-color
 
@@ -14385,7 +14349,7 @@ snapshots:
     dependencies:
       '@volar/typescript': 1.11.1
       '@vue/language-core': 1.8.27(typescript@5.8.3)
-      semver: 7.7.3
+      semver: 7.7.2
       typescript: 5.8.3
 
   w3c-xmlserializer@5.0.0:
@@ -14535,7 +14499,7 @@ snapshots:
     dependencies:
       lodash.get: 4.4.2
       lodash.isequal: 4.5.0
-      validator: 13.15.35
+      validator: 13.15.15
     optionalDependencies:
       commander: 9.5.0
 

--- a/scripts/regression-smoke.mjs
+++ b/scripts/regression-smoke.mjs
@@ -129,7 +129,7 @@ function requireEnv(name) {
 }
 
 function importPackage(packageName) {
-  const url = new URL(`../packages/${packageName}/dist/index.esm.js`, import.meta.url)
+  const url = new URL(`../packages/${packageName}/dist/index.js`, import.meta.url)
   return import(url)
 }
 


### PR DESCRIPTION
## Problem

See https://github.com/naviprotocol/naviprotocol-monorepo/issues/99

Packages emit a single bundled `index.esm.js` but separate `.d.ts` files with bare specifier re-exports:

```typescript
// index.d.ts
export * from './account';  // no .js extension
```

TypeScript's `moduleResolution: "NodeNext"` enforces Node.js ESM rules for types too. When resolving `export * from './account'`, it looks for `./account.js` first — which doesn't exist because JS is bundled. This breaks type resolution for NodeNext consumers.
I tested few approaches, one being using TS paths, but it doesn't work specifically because of the bad types.
One solution is to merge all the types in a single file, that way we're not referencing another file, maybe this would've been a simpler change to implement, but I didn't want to touch the current `.d.ts` build.

## Solution

- Emit individual `.js` files via `preserveModules: true` so each `.d.ts` has a matching `.js`
- Add `afterBuild` hook to rewrite `.d.ts` imports with `.js` extensions
- Update all package entry points from `index.esm.js` to `index.js`

## Affected packages

- `@naviprotocol/lending`
- `@naviprotocol/astros-aggregator-sdk`
- `@naviprotocol/astros-bridge-sdk`
- `@naviprotocol/astros-dca-sdk`
- `@naviprotocol/wallet-client`

Example output now with fixed structure:
<img width="457" height="744" alt="image" src="https://github.com/user-attachments/assets/4cd3b806-f263-49c9-a826-c4ef3f702774" />




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This changes published package layout and entry filenames (breaking for anyone importing `index.esm.js` directly), but scope is limited to build output and CI boundary/smoke checks.
> 
> **Overview**
> Fixes **NodeNext** type resolution by aligning published **JS** output with split **`.d.ts`** files instead of one bundled `index.esm.js`.
> 
> Shared **`vite.lib.config.js`** now builds with **`preserveModules`** (`[name].js`), runs an **`afterBuild`** pass to append **`.js`** on relative imports/re-exports in declarations, and generates missing **`index.js`** barrels from **`index.d.ts`** re-exports. **`main` / `module` / `exports`** on lending, wallet-client, and the Astros SDKs point at **`dist/index.js`**.
> 
> **`astros-bridge-sdk`** overrides Rollup to **`preserveModules: false`** so Mayan-related lazy chunks stay separate. **`check-sdk-v2-boundaries.mjs`** and **`regression-smoke.mjs`** expect **`index.js`** and scan **`require()`** across dist JS (with Mayan/Suilend artifact exceptions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01410863c41a2ad70280e628ba84d0357a0dbb53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->