### PR TITLE
release 2.0.6

### DIFF
--- a/.changeset/pyth-price-table-plain-dynamic-field.md
+++ b/.changeset/pyth-price-table-plain-dynamic-field.md
@@ -1,5 +1,0 @@
----
-'@naviprotocol/lending': patch
----
-
-Fix Pyth price feed updates on the v2 Core (gRPC) client: price table entries are plain dynamic fields, so they are now fetched via `getDynamicField` instead of `getDynamicObjectField`, whose `Wrapper<PriceIdentifier>` derivation resolved to a nonexistent object and aborted every price refresh ("failed to update pyth price feeds, msg: Object 0x...").

--- a/packages/lending/CHANGELOG.md
+++ b/packages/lending/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @naviprotocol/lending
 
+## 2.0.6
+
+### Patch Changes
+
+- cbbdcf6: Fix Pyth price feed updates on the v2 Core (gRPC) client: price table entries are plain dynamic fields, so they are now fetched via `getDynamicField` instead of `getDynamicObjectField`, whose `Wrapper<PriceIdentifier>` derivation resolved to a nonexistent object and aborted every price refresh ("failed to update pyth price feeds, msg: Object 0x...").
+
 ## 2.0.5
 
 ### Patch Changes

--- a/packages/lending/package.json
+++ b/packages/lending/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@naviprotocol/lending",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "NAVI Lending SDK",
   "license": "MIT",
   "type": "module",

--- a/packages/wallet-client/CHANGELOG.md
+++ b/packages/wallet-client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @naviprotocol/wallet-client
 
+## 2.0.6
+
+### Patch Changes
+
+- Updated dependencies [cbbdcf6]
+  - @naviprotocol/lending@2.0.6
+
 ## 2.0.5
 
 ### Patch Changes

--- a/packages/wallet-client/package.json
+++ b/packages/wallet-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@naviprotocol/wallet-client",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "NAVI Wallet Client",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Description

Describe the changes or additions included in this PR.

## Test plan

How did you test the new or updated feature?

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version and changelog-only release; the functional fix is already landed in lending and this PR does not change runtime code in the diff.
> 
> **Overview**
> **Release 2.0.6** for `@naviprotocol/lending` and `@naviprotocol/wallet-client`.
> 
> The lending package changelog documents patch **cbbdcf6**: Pyth price feed updates on the v2 Core (gRPC) client now read price table entries with `getDynamicField` instead of `getDynamicObjectField`, fixing aborted refreshes when `Wrapper<PriceIdentifier>` resolved to a missing on-chain object. Wallet-client is bumped to **2.0.6** with an updated dependency on `@naviprotocol/lending@2.0.6`.
> 
> The consumed changeset `.changeset/pyth-price-table-plain-dynamic-field.md` is removed as part of the release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c8ddc002c56b49f4ef0ffc2c55e9cc1f36465ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->