### PR TITLE
chore(release): bump packages for nodenext build fix

### DIFF
--- a/packages/astros-aggregator-sdk/CHANGELOG.md
+++ b/packages/astros-aggregator-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @naviprotocol/astros-aggregator-sdk
 
+## 2.0.5
+
+### Patch Changes
+
+- Fix NodeNext-compatible ESM output and package entry points.
+
 ## 2.0.4
 
 ### Patch Changes

--- a/packages/astros-aggregator-sdk/package.json
+++ b/packages/astros-aggregator-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@naviprotocol/astros-aggregator-sdk",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "NAVI Astros Aggregator SDK",
   "license": "MIT",
   "type": "module",

--- a/packages/astros-bridge-sdk/CHANGELOG.md
+++ b/packages/astros-bridge-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @naviprotocol/astros-bridge-sdk
 
+## 2.0.1
+
+### Patch Changes
+
+- Fix NodeNext-compatible ESM output and package entry points.
+
 ## 2.0.0-beta.1
 
 ### Patch Changes

--- a/packages/astros-bridge-sdk/package.json
+++ b/packages/astros-bridge-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@naviprotocol/astros-bridge-sdk",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "NAVI Astros Aggregator SDK",
   "license": "MIT",
   "type": "module",

--- a/packages/astros-dca-sdk/CHANGELOG.md
+++ b/packages/astros-dca-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @naviprotocol/astros-dca-sdk
 
+## 2.0.2
+
+### Patch Changes
+
+- Fix NodeNext-compatible ESM output and package entry points.
+
 ## 2.0.1
 
 ### Patch Changes

--- a/packages/astros-dca-sdk/package.json
+++ b/packages/astros-dca-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@naviprotocol/astros-dca-sdk",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "NAVI Astros DCA SDK",
   "license": "MIT",
   "type": "module",

--- a/packages/lending/CHANGELOG.md
+++ b/packages/lending/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @naviprotocol/lending
 
+## 2.0.7
+
+### Patch Changes
+
+- Fix NodeNext-compatible ESM output and package entry points.
+
 ## 2.0.6
 
 ### Patch Changes

--- a/packages/lending/package.json
+++ b/packages/lending/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@naviprotocol/lending",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "NAVI Lending SDK",
   "license": "MIT",
   "type": "module",

--- a/packages/wallet-client/CHANGELOG.md
+++ b/packages/wallet-client/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @naviprotocol/wallet-client
 
+## 2.0.7
+
+### Patch Changes
+
+- Fix NodeNext-compatible ESM output and package entry points.
+- Updated dependencies
+  - @naviprotocol/astros-aggregator-sdk@2.0.5
+  - @naviprotocol/lending@2.0.7
+
 ## 2.0.6
 
 ### Patch Changes

--- a/packages/wallet-client/package.json
+++ b/packages/wallet-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@naviprotocol/wallet-client",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "NAVI Wallet Client",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Description

Describe the changes or additions included in this PR.

## Test plan

How did you test the new or updated feature?

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Release-metadata-only bump with no application logic changes in the diff; risk is limited to consumers upgrading published package versions.
> 
> **Overview**
> **Patch release** for five `@naviprotocol/*` packages so npm consumers pick up a prior **NodeNext-compatible ESM build and `exports` entry-point** fix.
> 
> Bumped versions: `@naviprotocol/astros-aggregator-sdk` **2.0.5**, `@naviprotocol/astros-bridge-sdk` **2.0.1**, `@naviprotocol/astros-dca-sdk` **2.0.2**, `@naviprotocol/lending` **2.0.7**, and `@naviprotocol/wallet-client` **2.0.7**. Each package’s `CHANGELOG.md` records the same patch note; **wallet-client** also lists updated workspace deps on aggregator **2.0.5** and lending **2.0.7**.
> 
> This PR diff is **version and changelog only**—no runtime or build source changes in the diff itself.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7757b0e6eb9adb9c71d23df6a932496e25242f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->