### PR TITLE
fix(lending): support sender-funded Pyth fees

### DIFF
--- a/packages/lending/src/oracle.ts
+++ b/packages/lending/src/oracle.ts
@@ -15,9 +15,10 @@ import type {
   SuiClientOption,
   MarketOption,
   LendingPosition,
-  ServiceOption
+  ServiceOption,
+  TransactionObjectArgument
 } from './types'
-import { SuiPriceServiceConnection, SuiPythClient, type PythFeeSource } from './pyth'
+import { SuiPriceServiceConnection, SuiPythClient } from './pyth'
 import { Transaction } from '@mysten/sui/transactions'
 import { multiGetSuiObjects, suiClient } from './utils'
 import { getLendingPositions } from './account'
@@ -209,7 +210,7 @@ export async function updatePythPriceFeeds(
     SuiClientOption &
       EnvOption &
       MarketOption & {
-        pythFeeSource?: PythFeeSource
+        pythFeeCoin?: TransactionObjectArgument
       }
   >
 ) {
@@ -229,7 +230,7 @@ export async function updatePythPriceFeeds(
     )
 
     return await suiPythClient.updatePriceFeeds(tx as any, priceUpdateData, priceFeedIds, {
-      pythFeeSource: options?.pythFeeSource
+      feeCoin: options?.pythFeeCoin
     })
   } catch (error) {
     throw new Error(`failed to update pyth price feeds, msg: ${(error as Error).message}`)
@@ -257,11 +258,8 @@ export async function updateOraclePricesPTB(
       ServiceOption &
       MarketOption & {
         updatePythPriceFeeds?: boolean
-        /**
-         * Selects the SUI source for Pyth update fees. Defaults to `gasCoin`.
-         * Use `senderBalance` when the transaction kind must not consume its gas coin.
-         */
-        pythFeeSource?: PythFeeSource
+        /** Optional user-owned SUI coin used for Pyth update fees. Defaults to `tx.gas`. */
+        pythFeeCoin?: TransactionObjectArgument
       }
   >
 ): Promise<Transaction> {
@@ -394,7 +392,7 @@ export async function updateOraclePriceBeforeUserOperationPTB(
       SuiClientOption &
       MarketOption & {
         throws?: boolean
-        pythFeeSource?: PythFeeSource
+        pythFeeCoin?: TransactionObjectArgument
       }
   >
 ) {

--- a/packages/lending/src/oracle.ts
+++ b/packages/lending/src/oracle.ts
@@ -17,7 +17,7 @@ import type {
   LendingPosition,
   ServiceOption
 } from './types'
-import { SuiPriceServiceConnection, SuiPythClient } from './pyth'
+import { SuiPriceServiceConnection, SuiPythClient, type PythFeeSource } from './pyth'
 import { Transaction } from '@mysten/sui/transactions'
 import { multiGetSuiObjects, suiClient } from './utils'
 import { getLendingPositions } from './account'
@@ -205,7 +205,13 @@ export async function getPythStalePriceFeedIdV2(
 export async function updatePythPriceFeeds(
   tx: Transaction,
   priceFeedIds: string[],
-  options?: Partial<SuiClientOption & EnvOption & MarketOption>
+  options?: Partial<
+    SuiClientOption &
+      EnvOption &
+      MarketOption & {
+        pythFeeSource?: PythFeeSource
+      }
+  >
 ) {
   const client = options?.client ?? suiClient
   const config = await getConfig({
@@ -222,7 +228,9 @@ export async function updatePythPriceFeeds(
       config.oracle.wormholeStateId
     )
 
-    return await suiPythClient.updatePriceFeeds(tx as any, priceUpdateData, priceFeedIds)
+    return await suiPythClient.updatePriceFeeds(tx as any, priceUpdateData, priceFeedIds, {
+      pythFeeSource: options?.pythFeeSource
+    })
   } catch (error) {
     throw new Error(`failed to update pyth price feeds, msg: ${(error as Error).message}`)
   }
@@ -249,6 +257,11 @@ export async function updateOraclePricesPTB(
       ServiceOption &
       MarketOption & {
         updatePythPriceFeeds?: boolean
+        /**
+         * Selects the SUI source for Pyth update fees. Defaults to `gasCoin`.
+         * Use `senderBalance` when the transaction kind must not consume its gas coin.
+         */
+        pythFeeSource?: PythFeeSource
       }
   >
 ): Promise<Transaction> {
@@ -381,6 +394,7 @@ export async function updateOraclePriceBeforeUserOperationPTB(
       SuiClientOption &
       MarketOption & {
         throws?: boolean
+        pythFeeSource?: PythFeeSource
       }
   >
 ) {

--- a/packages/lending/src/pyth.ts
+++ b/packages/lending/src/pyth.ts
@@ -1,7 +1,8 @@
 import type { NaviSuiClient } from './sui'
-import { coinWithBalance, Transaction } from '@mysten/sui/transactions'
+import type { TransactionObjectArgument } from '@mysten/sui/transactions'
+import { Transaction } from '@mysten/sui/transactions'
 import { bcs } from '@mysten/sui/bcs'
-import { SUI_CLOCK_OBJECT_ID, SUI_TYPE_ARG } from '@mysten/sui/utils'
+import { SUI_CLOCK_OBJECT_ID } from '@mysten/sui/utils'
 
 type HermesPrice = {
   price: string
@@ -31,8 +32,6 @@ type PriceFeed = {
     publishTime: number
   }
 }
-
-export type PythFeeSource = 'gasCoin' | 'senderBalance'
 
 type CoreDynamicFieldName = {
   type: string
@@ -344,26 +343,15 @@ export class SuiPythClient {
     tx: Transaction,
     updates: Uint8Array[],
     feedIds: string[],
-    options?: { pythFeeSource?: PythFeeSource }
+    options?: { feeCoin?: TransactionObjectArgument }
   ) {
     const packageId = await this.getPythPackageId()
     const priceUpdatesHotPotato = await this.verifyVaasAndGetHotPotato(tx, updates, packageId)
     const baseUpdateFee = await this.getBaseUpdateFee()
-    const coins =
-      options?.pythFeeSource === 'senderBalance'
-        ? feedIds.map(() =>
-            tx.add(
-              coinWithBalance({
-                type: SUI_TYPE_ARG,
-                balance: baseUpdateFee,
-                useGasCoin: false
-              })
-            )
-          )
-        : tx.splitCoins(
-            tx.gas,
-            feedIds.map(() => tx.pure.u64(baseUpdateFee))
-          )
+    const coins = tx.splitCoins(
+      options?.feeCoin ?? tx.gas,
+      feedIds.map(() => tx.pure.u64(baseUpdateFee))
+    )
     return this.executePriceFeedUpdates(tx, packageId, feedIds, priceUpdatesHotPotato, coins)
   }
 

--- a/packages/lending/src/pyth.ts
+++ b/packages/lending/src/pyth.ts
@@ -1,7 +1,7 @@
 import type { NaviSuiClient } from './sui'
-import { Transaction } from '@mysten/sui/transactions'
+import { coinWithBalance, Transaction } from '@mysten/sui/transactions'
 import { bcs } from '@mysten/sui/bcs'
-import { SUI_CLOCK_OBJECT_ID } from '@mysten/sui/utils'
+import { SUI_CLOCK_OBJECT_ID, SUI_TYPE_ARG } from '@mysten/sui/utils'
 
 type HermesPrice = {
   price: string
@@ -31,6 +31,8 @@ type PriceFeed = {
     publishTime: number
   }
 }
+
+export type PythFeeSource = 'gasCoin' | 'senderBalance'
 
 type CoreDynamicFieldName = {
   type: string
@@ -338,14 +340,30 @@ export class SuiPythClient {
     }
   }
 
-  async updatePriceFeeds(tx: Transaction, updates: Uint8Array[], feedIds: string[]) {
+  async updatePriceFeeds(
+    tx: Transaction,
+    updates: Uint8Array[],
+    feedIds: string[],
+    options?: { pythFeeSource?: PythFeeSource }
+  ) {
     const packageId = await this.getPythPackageId()
     const priceUpdatesHotPotato = await this.verifyVaasAndGetHotPotato(tx, updates, packageId)
     const baseUpdateFee = await this.getBaseUpdateFee()
-    const coins = tx.splitCoins(
-      tx.gas,
-      feedIds.map(() => tx.pure.u64(baseUpdateFee))
-    )
+    const coins =
+      options?.pythFeeSource === 'senderBalance'
+        ? feedIds.map(() =>
+            tx.add(
+              coinWithBalance({
+                type: SUI_TYPE_ARG,
+                balance: baseUpdateFee,
+                useGasCoin: false
+              })
+            )
+          )
+        : tx.splitCoins(
+            tx.gas,
+            feedIds.map(() => tx.pure.u64(baseUpdateFee))
+          )
     return this.executePriceFeedUpdates(tx, packageId, feedIds, priceUpdatesHotPotato, coins)
   }
 

--- a/packages/lending/tests/pyth.test.ts
+++ b/packages/lending/tests/pyth.test.ts
@@ -67,148 +67,172 @@ describe('SuiPythClient', () => {
     vi.unstubAllGlobals()
   })
 
-  it('builds v2 price update PTB from Hermes update data with dynamic package ids, base fee, and price table lookup', async () => {
-    const pythStateId = `0x${'1'.repeat(64)}`
-    const wormholeStateId = `0x${'2'.repeat(64)}`
-    const pythPackageId = `0x${'3'.repeat(64)}`
-    const wormholePackageId = `0x${'4'.repeat(64)}`
-    const priceTableId = `0x${'5'.repeat(64)}`
-    const priceInfoObjectId = `0x${'6'.repeat(64)}`
-    const feedId = `0x${'a'.repeat(64)}`
-    const accumulatorMessage = Uint8Array.from([0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 1, 2, 3])
-    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
-      const url = new URL(String(input))
-      expect(url.pathname).toBe('/v2/updates/price/latest')
-      expect(url.searchParams.get('encoding')).toBe('base64')
-      expect(url.searchParams.get('parsed')).toBe('false')
-      expect(url.searchParams.getAll('ids[]')).toEqual(['a'.repeat(64)])
-      return new Response(
-        JSON.stringify({
-          binary: {
-            encoding: 'base64',
-            data: [btoa(String.fromCharCode(...Array.from(accumulatorMessage)))]
-          }
-        })
-      )
-    })
-    vi.stubGlobal('fetch', fetchMock)
-
-    const provider = {
-      getObject: vi.fn(async ({ id }: { id: string }) => {
-        if (id === pythStateId) {
-          return {
-            data: {
-              content: {
-                dataType: 'moveObject',
-                fields: {
-                  base_update_fee: '7',
-                  upgrade_cap: {
-                    fields: {
-                      package: pythPackageId
-                    }
-                  }
-                }
-              }
+  it.each([
+    { feeCoinSource: 'tx.gas', useExternalFeeCoin: false },
+    { feeCoinSource: 'an external SUI coin object', useExternalFeeCoin: true }
+  ])(
+    'builds v2 price update PTB using $feeCoinSource with dynamic package ids, base fee, and price table lookup',
+    async ({ useExternalFeeCoin }) => {
+      const pythStateId = `0x${'1'.repeat(64)}`
+      const wormholeStateId = `0x${'2'.repeat(64)}`
+      const pythPackageId = `0x${'3'.repeat(64)}`
+      const wormholePackageId = `0x${'4'.repeat(64)}`
+      const priceTableId = `0x${'5'.repeat(64)}`
+      const priceInfoObjectId = `0x${'6'.repeat(64)}`
+      const feeCoinObjectId = `0x${'7'.repeat(64)}`
+      const feedId = `0x${'a'.repeat(64)}`
+      const accumulatorMessage = Uint8Array.from([0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 1, 2, 3])
+      const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+        const url = new URL(String(input))
+        expect(url.pathname).toBe('/v2/updates/price/latest')
+        expect(url.searchParams.get('encoding')).toBe('base64')
+        expect(url.searchParams.get('parsed')).toBe('false')
+        expect(url.searchParams.getAll('ids[]')).toEqual(['a'.repeat(64)])
+        return new Response(
+          JSON.stringify({
+            binary: {
+              encoding: 'base64',
+              data: [btoa(String.fromCharCode(...Array.from(accumulatorMessage)))]
             }
-          }
-        }
-
-        if (id === wormholeStateId) {
-          return {
-            data: {
-              content: {
-                dataType: 'moveObject',
-                fields: {
-                  upgrade_cap: {
-                    fields: {
-                      package: wormholePackageId
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-
-        throw new Error(`unexpected object id ${id}`)
-      }),
-      getDynamicFieldObject: vi.fn(async ({ parentId, name }: { parentId: string; name: any }) => {
-        if (parentId === pythStateId) {
-          expect(name).toEqual({
-            type: 'vector<u8>',
-            value: 'price_info'
           })
-          return {
-            data: {
-              objectId: priceTableId,
-              type: `0x2::table::Table<${pythPackageId}::price_identifier::PriceIdentifier, 0x2::object::ID>`
-            }
-          }
-        }
+        )
+      })
+      vi.stubGlobal('fetch', fetchMock)
 
-        if (parentId === priceTableId) {
-          expect(name.type).toBe(`${pythPackageId}::price_identifier::PriceIdentifier`)
-          expect(name.value.bytes).toEqual(Array.from(Uint8Array.from({ length: 32 }, () => 0xaa)))
-          return {
-            data: {
-              content: {
-                dataType: 'moveObject',
-                fields: {
-                  value: priceInfoObjectId
+      const provider = {
+        getObject: vi.fn(async ({ id }: { id: string }) => {
+          if (id === pythStateId) {
+            return {
+              data: {
+                content: {
+                  dataType: 'moveObject',
+                  fields: {
+                    base_update_fee: '7',
+                    upgrade_cap: {
+                      fields: {
+                        package: pythPackageId
+                      }
+                    }
+                  }
                 }
               }
             }
           }
-        }
 
-        throw new Error(`unexpected dynamic field parent ${parentId}`)
+          if (id === wormholeStateId) {
+            return {
+              data: {
+                content: {
+                  dataType: 'moveObject',
+                  fields: {
+                    upgrade_cap: {
+                      fields: {
+                        package: wormholePackageId
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+          throw new Error(`unexpected object id ${id}`)
+        }),
+        getDynamicFieldObject: vi.fn(
+          async ({ parentId, name }: { parentId: string; name: any }) => {
+            if (parentId === pythStateId) {
+              expect(name).toEqual({
+                type: 'vector<u8>',
+                value: 'price_info'
+              })
+              return {
+                data: {
+                  objectId: priceTableId,
+                  type: `0x2::table::Table<${pythPackageId}::price_identifier::PriceIdentifier, 0x2::object::ID>`
+                }
+              }
+            }
+
+            if (parentId === priceTableId) {
+              expect(name.type).toBe(`${pythPackageId}::price_identifier::PriceIdentifier`)
+              expect(name.value.bytes).toEqual(
+                Array.from(Uint8Array.from({ length: 32 }, () => 0xaa))
+              )
+              return {
+                data: {
+                  content: {
+                    dataType: 'moveObject',
+                    fields: {
+                      value: priceInfoObjectId
+                    }
+                  }
+                }
+              }
+            }
+
+            throw new Error(`unexpected dynamic field parent ${parentId}`)
+          }
+        )
+      }
+
+      const tx = new Transaction()
+      const connection = new SuiPriceServiceConnection('https://hermes.pyth.network')
+      const updates = await connection.getPriceFeedsUpdateData([feedId])
+      const client = new SuiPythClient(provider as any, pythStateId, wormholeStateId)
+      const updatedObjects = await client.updatePriceFeeds(
+        tx,
+        updates,
+        [feedId],
+        useExternalFeeCoin
+          ? {
+              feeCoin: tx.object(feeCoinObjectId)
+            }
+          : undefined
+      )
+      const commands = tx.getData().commands
+      const moveCalls = commands.map((command: any) => command.MoveCall).filter(Boolean)
+      const splitCoinCommands = commands.map((command: any) => command.SplitCoins).filter(Boolean)
+
+      expect(updatedObjects).toEqual([priceInfoObjectId])
+      expect(provider.getObject).toHaveBeenCalledWith({
+        id: pythStateId,
+        options: { showContent: true }
       })
+      expect(provider.getObject).toHaveBeenCalledWith({
+        id: wormholeStateId,
+        options: { showContent: true }
+      })
+      expect(moveCalls).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            module: 'vaa',
+            function: 'parse_and_verify'
+          }),
+          expect.objectContaining({
+            module: 'pyth',
+            function: 'create_authenticated_price_infos_using_accumulator'
+          }),
+          expect.objectContaining({
+            module: 'pyth',
+            function: 'update_single_price_feed'
+          }),
+          expect.objectContaining({
+            module: 'hot_potato_vector',
+            function: 'destroy'
+          })
+        ])
+      )
+      expect(JSON.stringify(commands)).toContain(wormholePackageId)
+      expect(JSON.stringify(commands)).toContain(pythPackageId)
+      expect(splitCoinCommands).toHaveLength(1)
+      expect(splitCoinCommands[0].amounts).toHaveLength(1)
+      expect(splitCoinCommands[0].coin.$kind).toBe(useExternalFeeCoin ? 'Input' : 'GasCoin')
+      if (useExternalFeeCoin) {
+        expect(JSON.stringify(tx.getData().inputs)).toContain(feeCoinObjectId)
+      }
+      expect(fetchMock).toHaveBeenCalledOnce()
     }
-
-    const tx = new Transaction()
-    const connection = new SuiPriceServiceConnection('https://hermes.pyth.network')
-    const updates = await connection.getPriceFeedsUpdateData([feedId])
-    const client = new SuiPythClient(provider as any, pythStateId, wormholeStateId)
-    const updatedObjects = await client.updatePriceFeeds(tx, updates, [feedId])
-    const commands = tx.getData().commands
-    const moveCalls = commands.map((command: any) => command.MoveCall).filter(Boolean)
-    const splitCoinCommands = commands.map((command: any) => command.SplitCoins).filter(Boolean)
-
-    expect(updatedObjects).toEqual([priceInfoObjectId])
-    expect(provider.getObject).toHaveBeenCalledWith({
-      id: pythStateId,
-      options: { showContent: true }
-    })
-    expect(provider.getObject).toHaveBeenCalledWith({
-      id: wormholeStateId,
-      options: { showContent: true }
-    })
-    expect(moveCalls).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          module: 'vaa',
-          function: 'parse_and_verify'
-        }),
-        expect.objectContaining({
-          module: 'pyth',
-          function: 'create_authenticated_price_infos_using_accumulator'
-        }),
-        expect.objectContaining({
-          module: 'pyth',
-          function: 'update_single_price_feed'
-        }),
-        expect.objectContaining({
-          module: 'hot_potato_vector',
-          function: 'destroy'
-        })
-      ])
-    )
-    expect(JSON.stringify(commands)).toContain(wormholePackageId)
-    expect(JSON.stringify(commands)).toContain(pythPackageId)
-    expect(splitCoinCommands).toHaveLength(1)
-    expect(splitCoinCommands[0].amounts).toHaveLength(1)
-    expect(fetchMock).toHaveBeenCalledOnce()
-  })
+  )
 
   it('parses normalized Core price table types before fetching price feed dynamic fields', async () => {
     const pythStateId = `0x${'1'.repeat(64)}`


### PR DESCRIPTION
## Background and goal

Shinami rejects sponsored `TransactionKind` payloads that consume `GasCoin`.
The lending SDK previously hardcoded Pyth update fees to `tx.gas`, so lending
transactions containing Pyth updates failed at the sponsor endpoint with
JSON-RPC `-32602 (Invalid params)`.

This PR lets the application provide a sender-owned SUI coin object for Pyth
fees while keeping sponsorship policy outside the SDK.

## Changes

- add optional `pythFeeCoin` support to the public Pyth and oracle helpers
- split all Pyth update fees from the supplied transaction coin object
- preserve `tx.gas` as the backwards-compatible default when no coin is passed
- avoid creating `coinWithBalance` intents inside the Pyth SDK
- cover both the default gas coin and an external coin object in the Pyth PTB test

Sponsored callers can now pass an explicit user-owned SUI coin:

```ts
const pythFeeCoin = tx.objectRef({
  objectId,
  version,
  digest,
})

await updateOraclePricesPTB(tx, priceFeeds, {
  client,
  env,
  market,
  updatePythPriceFeeds: true,
  pythFeeCoin,
})
```

Non-sponsored callers do not need to change:

```ts
await updateOraclePricesPTB(tx, priceFeeds, {
  client,
  env,
  market,
  updatePythPriceFeeds: true,
})
```

In that case Pyth fees continue to be split from `tx.gas`.

## Consumer integration

The lending frontend selects a user-owned SUI coin object only when the
transaction will be sponsored and passes it through `pythFeeCoin`. This keeps
the SDK independent of sponsor policy and allows the application to coordinate
the fee coin with SUI deposit/repay coin selection.

A local `@naviprotocol/lending` package was built and linked into the frontend
to validate the final API and TypeScript integration before publication.

## Verification

- reproduced the original production failure: the transaction contained six
  Pyth fee splits from `GasCoin`, and the sponsor endpoint returned HTTP 500 /
  Shinami `-32602`
- confirmed with the earlier sender-balance prototype that removing `GasCoin`
  from the transaction kind allows the production sponsor endpoint to return
  HTTP 201
- replaced that prototype with the final external `pythFeeCoin` API so the SDK
  no longer creates hidden `coinWithBalance` intents
- Pyth targeted tests pass for both `tx.gas` and an external coin object
- `pnpm --filter @naviprotocol/lending build`
- `pnpm --filter @naviprotocol/lending test:types`
- frontend local-package TypeScript check and ESLint pass

The final external-coin transaction is pending the manual sponsor request
because the original test address has reached the campaign transaction-count
limit.

## Related work

- Issue: N/A
- Linear: N/A
- Incident: sponsored lending transactions with Pyth updates returning
  Shinami `-32602`
- Release: next `@naviprotocol/lending` release

## Risk and rollback

- Risk: sponsored callers must supply a valid sender-owned SUI coin object with
  enough balance for all Pyth update fees
- Compatibility: existing callers are unchanged because omitting
  `pythFeeCoin` retains the original `tx.gas` behavior
- Rollback: revert this PR and keep sponsored Pyth transactions disabled until
  fee-coin selection is handled by the caller

## Sensitive information check

- [x] This PR contains no keys, tokens, private keys, wallet secrets, or
  production credentials

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 1fea4b606860a49b3d18cf6d6473b50ac3fa268a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
