### PR TITLE
chore(release): update lending and wallet-client to version 2.0.8

### DIFF
--- a/packages/lending/CHANGELOG.md
+++ b/packages/lending/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @naviprotocol/lending
 
+## 2.0.8
+
+### Patch Changes
+
+- support sender-funded Pyth fees
+
 ## 2.0.7
 
 ### Patch Changes

--- a/packages/lending/package.json
+++ b/packages/lending/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@naviprotocol/lending",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "NAVI Lending SDK",
   "license": "MIT",
   "type": "module",

--- a/packages/wallet-client/CHANGELOG.md
+++ b/packages/wallet-client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @naviprotocol/wallet-client
 
+## 2.0.8
+
+### Patch Changes
+
+- Updated dependencies
+  - @naviprotocol/lending@2.0.8
+
 ## 2.0.7
 
 ### Patch Changes

--- a/packages/wallet-client/package.json
+++ b/packages/wallet-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@naviprotocol/wallet-client",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "NAVI Wallet Client",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
- Bump @naviprotocol/lending to 2.0.8, adding support for sender-funded Pyth fees.
- Update @naviprotocol/wallet-client to 2.0.8, reflecting the new lending version in dependencies.

## Description

Describe the changes or additions included in this PR.

## Test plan

How did you test the new or updated feature?

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version and changelog edits only; no runtime code changes in the PR diff.
> 
> **Overview**
> **Release-only PR:** bumps `@naviprotocol/lending` and `@naviprotocol/wallet-client` from **2.0.7** to **2.0.8** and records the release in each package’s `CHANGELOG.md` and `package.json`.
> 
> The lending changelog entry for 2.0.8 documents **sender-funded Pyth fees** as the patch change. Wallet-client’s changelog only notes an updated dependency on `@naviprotocol/lending@2.0.8`. No source changes appear in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b26fc6e1d945d287bde083c3a94f49812d553c0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->