### PR TITLE
feat(vault): add @naviprotocol/vault SDK

### DIFF
--- a/.changeset/wild-donkeys-shake.md
+++ b/.changeset/wild-donkeys-shake.md
@@ -1,0 +1,25 @@
+---
+'@naviprotocol/vault': minor
+'@naviprotocol/lending': patch
+---
+
+Add `@naviprotocol/vault`, an SDK for NAVI's single-asset yield vaults.
+
+Covers layout discovery, receipt attribution, simulation-based pricing and previews, and
+transaction builders for deposit, withdrawal, full exit and reward claims. Deposits and
+withdrawals emit the freshness prologue the contract requires — one `sync_market_balance`
+per registered market and one `collect_reward` per active market rule — and withdrawals
+additionally emit the oracle price update, delegated to `@naviprotocol/lending` so that
+oracle entrypoint revisions are picked up from configuration rather than an SDK release.
+
+Also exports `parseVaultError`, which classifies aborts across the three packages a vault
+transaction can fail in, so that `lending_core` 1400/1506 and oracle 1502 are not reported
+as user error.
+
+Read paths are verified against all four mainnet vaults. Transaction builders are
+verified by simulating the deposit, full-exit and claim blocks through the Move VM
+against live state, covering both the no-rule and harvest-required shapes; deposit and
+full exit were additionally executed on mainnet against SUI Prime.
+
+lending: export `devInspectTransaction`, previously internal, so dependent packages can
+simulate read-only blocks through the same v2 Core transport.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ Lending SDK that provides complete lending functionality.
 - 📊 Price Oracle Integration
 - 🏆 Reward System
 
+### [@naviprotocol/vault](./packages/vault/)
+Vault SDK for NAVI's single-asset yield vaults, which deploy deposits across NAVI lending markets.
+
+**Key Features:**
+- 🏦 Deposit, Withdraw, Full Exit
+- 📈 Simulation-Based Pricing and Share Valuation
+- 🎁 Reward Harvest and Claim
+- 🧭 On-Chain Layout Discovery
+- 🚨 Abort Classification (vault, lending and oracle codes)
+
 ### [@naviprotocol/wallet-client](./packages/wallet-client/)
 Comprehensive Wallet Client SDK that provides a unified interface for DeFi operations.
 

--- a/config/check-sdk-v2-boundaries.mjs
+++ b/config/check-sdk-v2-boundaries.mjs
@@ -6,6 +6,7 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..'
 
 const sdkPackages = [
   'lending',
+  'vault',
   'wallet-client',
   'astros-aggregator-sdk',
   'astros-bridge-sdk',

--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -37,6 +37,9 @@
       "@naviprotocol/lending": [
         "../packages/lending/src/index.ts"
       ],
+      "@naviprotocol/vault": [
+        "../packages/vault/src/index.ts"
+      ],
       "@naviprotocol/wallet-client": [
         "../packages/wallet-client/src/index.ts"
       ]

--- a/packages/lending/src/index.ts
+++ b/packages/lending/src/index.ts
@@ -35,7 +35,14 @@ export * from './reward'
 export * from './types'
 
 // Export utility functions with specific naming
-export { withCache, withSingleton, normalizeCoinType, parseTxValue, parsePoolUID } from './utils'
+export {
+  withCache,
+  withSingleton,
+  normalizeCoinType,
+  parseTxValue,
+  parsePoolUID,
+  devInspectTransaction
+} from './utils'
 
 // Export account capability management
 export * from './account-cap'

--- a/packages/vault/.eslintrc.cjs
+++ b/packages/vault/.eslintrc.cjs
@@ -1,0 +1,11 @@
+const base = require('../../config/.eslintrc.js')
+module.exports = {
+  ...base,
+  parserOptions: {
+    project: 'tsconfig.json',
+    tsconfigRootDir: __dirname
+  },
+  // scripts/ holds manual mainnet tooling; it is outside tsconfig's `include` and is
+  // never published (package.json `files` ships dist and README only).
+  ignorePatterns: [...base.ignorePatterns, 'functions/**/*.ts', 'scripts/**/*.ts']
+}

--- a/packages/vault/README.md
+++ b/packages/vault/README.md
@@ -1,0 +1,172 @@
+# @naviprotocol/vault
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+NAVI Vault SDK for the Sui blockchain. A vault accepts deposits of a single asset, issues proportional shares, and deploys the assets across one or more NAVI lending markets. Yield accrues to share value.
+
+## Documentation
+
+For SDK documentation visit http://sdk.naviprotocol.io/vault
+
+## Installation
+
+```npm
+npm install @naviprotocol/vault
+```
+
+## Core Concepts
+
+### Receipts, not share tokens
+
+A position is a `Receipt` object, not a coin. Transferring the Receipt transfers the position. A holder may hold several Receipts against one vault; each is independent and they never merge.
+
+`buildDepositTx` resolves which position to credit via the `position` argument:
+
+| `position`   | Behaviour                                                                                                                                                                       |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| omitted      | Reuse the sender's Receipt when they hold exactly one, mint a new one when they hold none. Several is ambiguous and raises an error listing them. Costs one extra read (~60ms). |
+| a receipt id | Credit that position. No lookup.                                                                                                                                                |
+| `'new'`      | Open a fresh position. No lookup.                                                                                                                                               |
+
+Guessing among several is deliberately not done: a Receipt _is_ a position, merging two is not reversible in place, and silently topping one up is what leaves stray empty Receipts behind.
+
+`Receipt` is **not generic** — a single type covers every vault on the deployment. Attributing one to a vault means reading its `vault_address` field, which matters concretely: two vaults share `0x2::sui::SUI` and two more share USDC.
+
+### Snapshot accounting
+
+A market position's value is a cached figure, written only by `sync_market_balance`. Between calls it understates the position by all interest accrued since. Because synchronization only happens as a side effect of someone transacting, an inactive vault can carry a snapshot weeks old.
+
+Two consequences shape the whole API:
+
+- **Deposits and withdrawals are multi-command blocks.** Every registered market must be synchronized and every active market reward rule harvested in the _same_ transaction, so a deposit is `M + R + 1` Move calls.
+- **Prices come from simulation.** Every pricing helper evaluates a read-only block that synchronizes before reading. Reading the vault object's fields directly returns the stale figure with no indication of its age.
+
+### Withdrawal routing
+
+The idle balance is drawn down first; the chosen market supplies only the shortfall. Withdrawing from the default market carries no penalty; any other market applies its own, capped at 30%, to the portion actually taken from it.
+
+A full exit uses `fromDefault` with `u64::MAX`, which the contract clamps to the holder's maximum. It normally clears the position exactly — verified on mainnet, shares and balance both reach zero.
+
+The exception is the **sole remaining holder**. The virtual-share offset that blocks inflation attacks means redeeming the entire balance would require burning `total_shares + VIRTUAL_SHARES`, which they do not have, so they may need a second withdrawal or leave a small remainder. Multi-holder exits are unaffected. Either way, read the returned coin value or the post-exit balance rather than assuming.
+
+## Usage
+
+```ts
+import { SuiGrpcClient, GrpcWebFetchTransport } from '@mysten/sui/grpc'
+import {
+  buildDepositTx,
+  buildExitAllTx,
+  findReceipts,
+  getVaultQuote,
+  sharePrice
+} from '@naviprotocol/vault'
+
+const client = new SuiGrpcClient({
+  network: 'mainnet',
+  transport: new GrpcWebFetchTransport({ baseUrl: 'https://fullnode.mainnet.sui.io:443' })
+})
+
+// Synchronized pricing
+const quote = await getVaultQuote('USDC', { client })
+console.log(quote.totalAssets, sharePrice(quote))
+
+// Deposit 10 USDC (6 decimals)
+const tx = await buildDepositTx({ vault: 'USDC', amount: 10_000_000n, sender }, { client })
+
+// Full exit
+const [receipt] = await findReceipts(sender, 'USDC', { client })
+const { transaction } = await buildExitAllTx(
+  { vault: 'USDC', receiptId: receipt.objectId, sender },
+  { client }
+)
+```
+
+## Code Style and Conventions
+
+### Two layers
+
+- `*PTB` functions are synchronous command emitters. They append Move calls to a transaction you own and perform no network I/O. Use them when you need a vault operation inside a larger block.
+- `build*Tx` functions are async and assemble a complete, submittable transaction, including the freshness prologue and — for withdrawals — the oracle price update.
+
+### Interface optional parameters
+
+The last `options` parameter customizes behaviour:
+
+- `client`: Sui SDK v2 client. Required for anything that reads chain state.
+- `config`: overrides the bundled configuration snapshot for this call.
+- `layout`: a `VaultLayout` already read during construction of the current transaction, skipping a round trip.
+- `env`, `services`: forwarded to `@naviprotocol/lending` for oracle configuration.
+
+### Configuration
+
+The bundled `MAINNET_VAULT_CONFIG` snapshot is a fallback so the SDK works with no setup. It is not authoritative — `packageId` changes on every contract upgrade, and a stale value silently runs superseded code. Production deployments should supply their own via `configureVaultSdk`.
+
+Live values — pause state, caps, fees, penalties, market membership, rule activity — are never read from configuration. They come from `getVaultLayout`, and **must not be cached across transactions**: `add_market` and `set_loss` both invalidate a layout in ways that make a transaction built from it abort.
+
+Use `diffLayoutAgainstConfig` to detect drift between a configuration snapshot and chain.
+
+### Units
+
+| Quantity                                               | Scale                                      |
+| ------------------------------------------------------ | ------------------------------------------ |
+| Amounts (`amount`, `currentBalance`, `totalAssets`, …) | Token native decimals                      |
+| `MarketLayout.loss`                                    | Always 9 decimals, regardless of the token |
+| `managementFee`, `performanceFee`, `penalty`           | WAD — `1e18 = 100%`                        |
+| `vaultRewardIndex`, `rewardRate`                       | RAY — `1e27`; rate is per millisecond      |
+| `lastSyncAtMs`, `lastHarvestAtMs`                      | Milliseconds                               |
+| Timelock timestamps                                    | Seconds                                    |
+
+Raw on-chain integers are `bigint` throughout. `wadToPercent` and `formatUnits` are for display only.
+
+### Slippage
+
+`maxShares` bounds the shares a withdrawal burns. **`0n` means "no limit", not "no shares"** — the contract skips the check entirely. `buildWithdrawTx` rejects it rather than silently submitting an unprotected withdrawal.
+
+Derive the bound by simulating: `convert_to_shares` models none of the market penalty, ceiling rounding, idle-first routing, or same-transaction fee accrual that determine what is actually burned. `buildWithdrawTxWithPreview` does this for you.
+
+### Error classification
+
+A vault transaction can abort from three packages, and the external codes are the ones most often misreported as user error:
+
+| Code            | Meaning                                          | Treat as                                                                                                               |
+| --------------- | ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| `10001`–`10042` | `navi_vault`                                     | See `parseVaultError`                                                                                                  |
+| `1400`          | Vault linked against a superseded `lending_core` | Protocol outage. Not recoverable client-side; suppress balances and block deposits until the vault package is upgraded |
+| `1502`          | Oracle price outside its freshness window        | Transient; the withdrawal block needs its oracle prologue                                                              |
+| `1506`          | NAVI reserve too utilized to release assets      | Transient liquidity, not the holder's balance                                                                          |
+| `1604`          | NAVI reserve supply ceiling reached              | External cap, shared with other participants in that reserve                                                           |
+
+```ts
+import { parseVaultError, isProtocolOutage } from '@naviprotocol/vault'
+
+const decoded = parseVaultError(error)
+if (decoded?.kind === 'liquidity') {
+  /* offer another market */
+}
+if (isProtocolOutage(error)) {
+  /* stop quoting, stop accepting deposits */
+}
+```
+
+## Status
+
+Read paths — layout discovery, receipt attribution, quoting, previews — are verified against all four mainnet vaults.
+
+Transaction builders are verified by **simulation against live mainnet state**: the deposit, full-exit and reward-claim blocks are executed through the Move VM with real vault state, real positions and real reward rules, covering both the no-rule shape (SUI Prime) and the harvest-required shape (SUI High Yield). Simulation discards the mutable references, so nothing is written and nothing is signed.
+
+Deposit and full exit have additionally been **executed on mainnet** against SUI Prime — the deposit topped up an existing position without minting a second receipt, and the exit cleared the position to zero and returned the full balance. Gas came in at ~0.0033 SUI to top up, ~0.0070 SUI to open a new position, ~0.0045 SUI to exit.
+
+Reward claim has been simulated but not executed, since the vaults carrying reward rules are not the ones used for validation.
+
+`scripts/mainnet-roundtrip.ts` is the tool used for this. It moves real funds, so it is run manually and never automated — every step simulates first and prints the projection, and nothing is submitted without `--confirm`:
+
+```bash
+export SUI_PRIVATE_KEY=suiprivkey1...
+pnpm --filter @naviprotocol/vault roundtrip -- --vault=SUI_PRIME --amount=0.1
+```
+
+That is a dry run. Add `--confirm` and `--step=deposit|claim|exit` to execute one step at a time. SUI Prime is the recommended first target: no reward rules, six commands, and a simulated full exit leaves a 1 mist remainder.
+
+## Support
+
+- Issues: [GitHub Issues](https://github.com/naviprotocol/naviprotocol-monorepo/issues)

--- a/packages/vault/package.json
+++ b/packages/vault/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "@naviprotocol/vault",
+  "version": "0.1.0",
+  "description": "NAVI Vault SDK",
+  "license": "MIT",
+  "type": "module",
+  "keywords": [
+    "navi",
+    "vault",
+    "lending",
+    "sui"
+  ],
+  "author": "NAVI",
+  "homepage": "https://sdk.naviprotocol.io/vault",
+  "bugs": "https://github.com/naviprotocol/naviprotocol-monorepo/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/naviprotocol/naviprotocol-monorepo.git"
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "source": "src/index.ts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "build": "run-p build:lib",
+    "build:lib": "vite build",
+    "prettier": "prettier --check src/",
+    "prettier:fix": "prettier --write src/",
+    "lint": "eslint . --ext .ts,.tsx",
+    "lint:fix": "eslint . --ext .ts,.tsx --fix",
+    "verify": "run-p prettier lint",
+    "verify:fix": "run-p prettier:fix lint:fix",
+    "test": "vitest --config ./vite.config.unit.js",
+    "test:types": "pnpm build:lib && tsc --noEmit -p tsconfig.type-tests.json",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "typedoc": "typedoc",
+    "roundtrip": "tsx scripts/mainnet-roundtrip.ts"
+  },
+  "dependencies": {
+    "@naviprotocol/lending": "workspace:^",
+    "bignumber.js": "9.1.2"
+  },
+  "devDependencies": {
+    "@mysten/sui": "2.20.2",
+    "@types/node": "22.7.5",
+    "tsconfig-paths": "4.2.0",
+    "tsx": "4.19.2",
+    "typescript": "5.8.3",
+    "vitest": "3.2.4"
+  },
+  "peerDependencies": {
+    "@mysten/sui": ">=2.0.0"
+  }
+}

--- a/packages/vault/scripts/mainnet-roundtrip.ts
+++ b/packages/vault/scripts/mainnet-roundtrip.ts
@@ -1,0 +1,312 @@
+/**
+ * Mainnet round-trip validation for the vault transaction builders.
+ *
+ * MOVES REAL FUNDS. Run it yourself; never automate it. It exists to cover the two
+ * things simulation cannot: gas estimation, and execution under contention.
+ *
+ * Every step simulates first and prints the projection. Nothing is submitted unless
+ * --confirm is passed, and each submission is reported with its digest before the next
+ * step runs.
+ *
+ * Usage:
+ *
+ *   export SUI_PRIVATE_KEY=suiprivkey1...        # bech32; never committed, never logged
+ *
+ *   # 1. dry run — simulates every step, submits nothing
+ *   pnpm --filter @naviprotocol/vault roundtrip -- --vault=SUI_PRIME --amount=0.1
+ *
+ *   # 2. for real, one step at a time
+ *   ... --vault=SUI_PRIME --amount=0.1 --step=deposit --confirm
+ *   ... --vault=SUI_PRIME --step=claim   --confirm
+ *   ... --vault=SUI_PRIME --step=exit    --confirm
+ *
+ * A deposit tops up the sender's existing position when they hold exactly one and opens a
+ * new one when they hold none. Holding several is ambiguous — pass --position=<receiptId>
+ * to pick one, or --position=new to open another.
+ *
+ * Recommended first target is SUI Prime: no reward rules, so the deposit block is six
+ * commands. Deposit and full exit have both been executed against it on mainnet.
+ */
+import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519'
+import { Transaction } from '@mysten/sui/transactions'
+import { createNaviSuiClient } from '@naviprotocol/lending'
+import {
+  buildClaimRewardTx,
+  buildDepositTx,
+  buildExitAllTx,
+  findReceipts,
+  estimateGas,
+  formatUnits,
+  getVaultConfig,
+  getVaultLayout,
+  getVaultPositions,
+  getVaultQuote,
+  parseVaultError,
+  previewClaimReward,
+  previewWithdraw,
+  resolveVault,
+  MAX_U64,
+  sharePrice
+} from '../src'
+import type { VaultDescriptor } from '../src'
+
+type Step = 'deposit' | 'claim' | 'exit'
+
+function arg(name: string): string | undefined {
+  const hit = process.argv.find((value) => value.startsWith(`--${name}=`))
+  return hit?.slice(name.length + 3)
+}
+
+const VAULT_KEY = arg('vault') ?? 'SUI_PRIME'
+const AMOUNT_HUMAN = arg('amount') ?? '0.1'
+const STEP = (arg('step') ?? 'all') as Step | 'all'
+const CONFIRM = process.argv.includes('--confirm')
+/**
+ * Which position to credit: a receipt id, or 'new' to open a fresh one. Omit to let the
+ * SDK reuse the sender's, if they hold exactly one.
+ */
+const POSITION = arg('position')
+
+function toBaseUnits(human: string, decimals: number): bigint {
+  const [whole = '0', fraction = ''] = human.split('.')
+  return BigInt(whole + fraction.padEnd(decimals, '0').slice(0, decimals))
+}
+
+function loadKeypair(): Ed25519Keypair {
+  const secret = process.env.SUI_PRIVATE_KEY
+  if (!secret) {
+    throw new Error('SUI_PRIVATE_KEY is not set. Export the bech32 suiprivkey1... value.')
+  }
+  // Never printed, never written anywhere.
+  return Ed25519Keypair.fromSecretKey(secret)
+}
+
+const client = createNaviSuiClient() as never
+const options = { client }
+
+// Resolved inside main() so a missing key is reported by the handler below rather than
+// as an uncaught top-level throw.
+let keypair: Ed25519Keypair
+let sender: string
+
+type GasUsed = {
+  computationCost?: string | number
+  storageCost?: string | number
+  storageRebate?: string | number
+}
+
+type ExecuteResult = {
+  Transaction?: { digest?: string; effects?: { status?: unknown; gasUsed?: GasUsed } }
+  FailedTransaction?: {
+    digest?: string
+    effects?: { status?: unknown; errors?: unknown[]; gasUsed?: GasUsed }
+  }
+}
+
+/** Net gas a completed transaction actually charged, in MIST. */
+function actualNetGas(gasUsed: GasUsed | undefined): bigint | undefined {
+  if (!gasUsed) return undefined
+  const n = (v: string | number | undefined) => BigInt(v ?? 0)
+  return n(gasUsed.computationCost) + n(gasUsed.storageCost) - n(gasUsed.storageRebate)
+}
+
+async function submit(tx: Transaction, label: string, estimated?: bigint): Promise<string> {
+  tx.setSenderIfNotSet(sender)
+  const bytes = await tx.build({ client: client as never })
+  const signed = await keypair.signTransaction(bytes)
+
+  const core = (
+    client as {
+      core: {
+        executeTransaction(input: unknown): Promise<ExecuteResult>
+        waitForTransaction(input: unknown): Promise<unknown>
+      }
+    }
+  ).core
+
+  const result = await core.executeTransaction({
+    transaction: bytes,
+    signatures: [signed.signature],
+    include: { effects: true, events: true, balanceChanges: true }
+  })
+
+  // The response is an envelope keyed by outcome, the same shape simulate returns —
+  // `Transaction` on success, `FailedTransaction` otherwise. Both carry the digest.
+  const failed = result.FailedTransaction
+  const digest = (result.Transaction ?? failed)?.digest
+  if (!digest) {
+    throw new Error(`${label} returned no digest: ${JSON.stringify(result).slice(0, 300)}`)
+  }
+  if (failed) {
+    throw new Error(`${label} failed on chain (${digest}): ${JSON.stringify(failed.effects)}`)
+  }
+
+  console.log(`   submitted ${label}: ${digest}`)
+  console.log(`   https://suiscan.xyz/mainnet/tx/${digest}`)
+
+  // Report what it actually cost, not just what was projected — validating gas is one of
+  // the two things this script exists for, and an estimate alone cannot do that.
+  const actual = actualNetGas(result.Transaction?.effects?.gasUsed)
+  if (actual !== undefined) {
+    const drift =
+      estimated !== undefined && actual > 0n
+        ? ` (estimate was ${formatUnits(estimated, 9)}, ` +
+          `${estimated >= actual ? '+' : '-'}${
+            Number(
+              ((estimated > actual ? estimated - actual : actual - estimated) * 1000n) / actual
+            ) / 10
+          }%)`
+        : ''
+    console.log(`   actual gas ${formatUnits(actual, 9)} SUI${drift}`)
+  }
+
+  // Reads that follow must observe this transaction. Without the wait, the next report
+  // can be served by a node that has not caught up and will show pre-transaction figures.
+  await core.waitForTransaction({ digest })
+  return digest
+}
+
+async function report(descriptor: VaultDescriptor, when: string): Promise<void> {
+  const quote = await getVaultQuote(descriptor, options)
+  const receipts = await findReceipts(sender, descriptor, options)
+  const positions = await getVaultPositions(
+    receipts.map((receipt) => receipt.objectId),
+    descriptor,
+    options
+  )
+  console.log(`\n── ${when} ──`)
+  console.log(
+    `   vault TVL ${formatUnits(quote.totalAssets, descriptor.decimals)} ` +
+      `| share price ${sharePrice(quote).toFixed(9)}`
+  )
+  if (positions.length === 0) {
+    console.log('   holder has no receipts')
+  }
+  for (const position of positions) {
+    console.log(
+      `   receipt ${position.receiptId.slice(0, 10)}… ` +
+        `shares=${position.shares} balance=${formatUnits(position.balance, descriptor.decimals)}`
+    )
+  }
+}
+
+async function main(): Promise<void> {
+  keypair = loadKeypair()
+  sender = keypair.getPublicKey().toSuiAddress()
+
+  const config = await getVaultConfig(options)
+  const descriptor = resolveVault(VAULT_KEY, config)
+  const amount = toBaseUnits(AMOUNT_HUMAN, descriptor.decimals)
+
+  console.log(`vault    ${descriptor.displayName} (${descriptor.vault})`)
+  console.log(`sender   ${sender}`)
+  console.log(`amount   ${AMOUNT_HUMAN} (${amount} base units)`)
+  console.log(`step     ${STEP}`)
+  console.log(
+    `mode     ${CONFIRM ? '*** SUBMITTING REAL TRANSACTIONS ***' : 'dry run (simulate only)'}`
+  )
+
+  const layout = await getVaultLayout(descriptor, options)
+  if (layout.paused) throw new Error('Vault is paused.')
+  console.log(
+    `layout   version=${layout.version} markets=${layout.markets.length} ` +
+      `rules=${layout.rules.length}`
+  )
+
+  await report(descriptor, 'before')
+
+  if (STEP === 'all' || STEP === 'deposit') {
+    console.log('\n[1] deposit')
+    const tx = await buildDepositTx(
+      {
+        vault: descriptor,
+        amount,
+        sender,
+        ...(POSITION ? { position: POSITION } : {})
+      },
+      options
+    )
+    console.log(`   commands: ${tx.getData().commands.length}`)
+    // estimateGas simulates and throws on abort, so it doubles as the dry run.
+    const gas = await estimateGas(tx, { ...options, sender })
+    console.log(`   simulation OK  |  gas ~${formatUnits(gas.netCost, 9)} SUI`)
+    if (CONFIRM) await submit(tx, 'deposit', gas.netCost)
+  }
+
+  const receipts = await findReceipts(sender, descriptor, options)
+  const receiptId = POSITION && POSITION !== 'new' ? POSITION : receipts[0]?.objectId
+  if (receipts.length > 1 && !POSITION) {
+    console.log(
+      `\n   note: sender holds ${receipts.length} receipts; steps below act on ` +
+        `${receiptId?.slice(0, 10)}…. Pass --position=<id> to choose.`
+    )
+  }
+
+  if ((STEP === 'all' || STEP === 'claim') && receiptId) {
+    console.log('\n[2] claim rewards')
+    const coinTypes = [
+      ...new Set(layout.rules.filter((rule) => rule.isActive).map((rule) => rule.rewardCoinType))
+    ]
+    if (coinTypes.length === 0) console.log('   vault pays no rewards; skipping')
+    for (const rewardCoinType of coinTypes) {
+      const claimable = await previewClaimReward(
+        { vault: descriptor, receiptId, rewardCoinType, sender },
+        options
+      )
+      console.log(`   ${rewardCoinType} claimable=${claimable}`)
+      if (claimable === 0n) {
+        console.log('   nothing to claim; skipping to avoid a zero-valued coin object')
+        continue
+      }
+      const tx = await buildClaimRewardTx(
+        { vault: descriptor, receiptId, rewardCoinType, sender },
+        options
+      )
+      const claimGas = await estimateGas(tx, { ...options, sender })
+      if (CONFIRM) await submit(tx, 'claim', claimGas.netCost)
+    }
+  }
+
+  if ((STEP === 'all' || STEP === 'exit') && receiptId) {
+    console.log('\n[3] full exit')
+    const preview = await previewWithdraw(
+      { vault: descriptor, receiptId, amount: MAX_U64, sender },
+      options
+    )
+    console.log(
+      `   burns ${preview.sharesBurned} shares, returns ` +
+        `${preview.amountOut !== undefined ? formatUnits(preview.amountOut, descriptor.decimals) : '?'} ` +
+        `| maxShares ${preview.maxShares} (+${preview.toleranceBps}bps)`
+    )
+    const { transaction } = await buildExitAllTx({ vault: descriptor, receiptId, sender }, options)
+    const exitGas = await estimateGas(transaction, { ...options, sender })
+    console.log(
+      `   commands: ${transaction.getData().commands.length}  |  ` +
+        `gas ~${formatUnits(exitGas.netCost, 9)} SUI`
+    )
+    if (CONFIRM) await submit(transaction, 'exit', exitGas.netCost)
+  }
+
+  await report(descriptor, 'after')
+
+  if (!CONFIRM) {
+    console.log('\nDry run complete. Nothing was submitted. Re-run with --confirm to execute.')
+  } else {
+    console.log(
+      '\nDone. A full exit normally clears the position exactly; only the sole remaining ' +
+        'holder can be left with a remainder, because the virtual-share offset prevents ' +
+        'them draining the vault in one transaction. Check the "after" figures either way.'
+    )
+  }
+}
+
+main().catch((error) => {
+  const decoded = parseVaultError(error)
+  if (decoded) {
+    console.error(`\nFAILED [${decoded.name}/${decoded.code}] (${decoded.kind})`)
+    console.error(decoded.message)
+  } else {
+    console.error(`\nFAILED: ${error instanceof Error ? error.message : String(error)}`)
+  }
+  process.exitCode = 1
+})

--- a/packages/vault/src/bcs.ts
+++ b/packages/vault/src/bcs.ts
@@ -1,0 +1,24 @@
+/**
+ * Vault BCS Schemas
+ *
+ * BCS layouts for vault objects read as raw Move struct content.
+ *
+ * @module VaultBcs
+ */
+
+import { bcs } from '@mysten/sui/bcs'
+
+/**
+ * `navi_vault::Receipt`.
+ *
+ * The struct is `{ id: UID, vault_address: address }`. A `UID` is a `sui::object::ID`
+ * wrapping a single address, so it serializes as 32 raw bytes with no framing — the
+ * whole struct is exactly two addresses.
+ *
+ * `Receipt` is deliberately not generic: one type covers every vault on the deployment,
+ * which is why {@link ReceiptStruct.vault_address} has to be read to attribute it.
+ */
+export const ReceiptStruct = bcs.struct('Receipt', {
+  id: bcs.Address,
+  vault_address: bcs.Address
+})

--- a/packages/vault/src/config.ts
+++ b/packages/vault/src/config.ts
@@ -1,0 +1,111 @@
+/**
+ * Vault Configuration Resolution
+ *
+ * Resolves the package ids, shared objects and vault descriptors the SDK needs.
+ *
+ * The bundled {@link MAINNET_VAULT_CONFIG} snapshot is the default so the SDK works
+ * with no setup, but it is a fallback, not a source of truth: `packageId` changes on
+ * every contract upgrade and a stale value silently runs superseded code. Deployments
+ * should feed their own configuration through {@link configureVaultSdk}.
+ *
+ * @module VaultConfig
+ */
+
+import { NaviVaultError } from './errors'
+import { MAINNET_VAULT_CONFIG } from './snapshot'
+import type { VaultConfig, VaultDescriptor, VaultIdentifier, VaultReadOptions } from './types'
+
+/** Move module every vault entrypoint lives in. */
+export const VAULT_MODULE = 'navi_vault'
+
+/** Fee rates and market penalties are scaled by this. `1e18` = 100%. */
+export const WAD = 1_000_000_000_000_000_000n
+
+/** Reward indices and rates are scaled by this. Rates are per millisecond. */
+export const RAY = 1_000_000_000_000_000_000_000_000_000n
+
+/** Largest `u64`. Pass as a withdrawal amount with `fromDefault` to request a full exit. */
+export const MAX_U64 = 18_446_744_073_709_551_615n
+
+/**
+ * Virtual share offset the contract adds on both sides of the share/asset conversion to
+ * make donation-based inflation attacks uneconomic.
+ *
+ * Consequence worth surfacing in a UI: a holder of 100% of shares cannot drain the vault
+ * in one transaction, because redeeming all assets would require burning
+ * `total_shares + VIRTUAL_SHARES`. A full exit leaves dust behind. This is by design.
+ */
+export const VIRTUAL_SHARES = 1_000_000n
+
+/** Sui's all-zero address. `defaultMarket` takes this value when deposits go to idle. */
+export const ZERO_ADDRESS = `0x${'0'.repeat(64)}`
+
+/** Seconds in a year, as used by the contract's management fee accrual. */
+export const SECONDS_PER_YEAR = 31_536_000n
+
+let overrideConfig: VaultConfig | undefined
+
+/**
+ * Installs a configuration that replaces the bundled snapshot for every subsequent call.
+ *
+ * Pass the values your deployment resolves from chain or from a configuration service.
+ * Call with `undefined` to fall back to the snapshot again.
+ */
+export function configureVaultSdk(config: VaultConfig | undefined): void {
+  overrideConfig = config
+}
+
+/**
+ * Returns the active vault configuration.
+ *
+ * Async by design: the resolution source is expected to move to a remote endpoint, and
+ * an async signature keeps that change from breaking callers.
+ */
+export async function getVaultConfig(options?: VaultReadOptions): Promise<VaultConfig> {
+  return options?.config ?? overrideConfig ?? MAINNET_VAULT_CONFIG
+}
+
+function normalizeId(value: string): string {
+  const hex = value.startsWith('0x') ? value.slice(2) : value
+  return `0x${hex.toLowerCase().padStart(64, '0')}`
+}
+
+/** True when the address is Sui's zero address in any padding. */
+export function isZeroAddress(value: string | null | undefined): boolean {
+  return !value || normalizeId(value) === ZERO_ADDRESS
+}
+
+/**
+ * Resolves a vault identifier to its descriptor.
+ *
+ * Accepts a descriptor (returned as-is), a config key such as `USDC_PRIME`, or a vault
+ * object id in any padding.
+ */
+export function resolveVault(identifier: VaultIdentifier, config: VaultConfig): VaultDescriptor {
+  if (typeof identifier !== 'string') return identifier
+
+  const byKey = config.vaults.find((vault) => vault.key === identifier)
+  if (byKey) return byKey
+
+  const target = normalizeId(identifier)
+  const byId = config.vaults.find((vault) => normalizeId(vault.vault) === target)
+  if (byId) return byId
+
+  throw new NaviVaultError({
+    code: 0,
+    name: 'VAULT_NOT_CONFIGURED',
+    kind: 'config',
+    message: `No vault matches "${identifier}". Known keys: ${config.vaults
+      .map((vault) => vault.key)
+      .join(', ')}.`,
+    raw: identifier
+  })
+}
+
+/** Resolves a vault identifier against the active configuration. */
+export async function getVault(
+  identifier: VaultIdentifier,
+  options?: VaultReadOptions
+): Promise<VaultDescriptor> {
+  return resolveVault(identifier, await getVaultConfig(options))
+}

--- a/packages/vault/src/deposit.ts
+++ b/packages/vault/src/deposit.ts
@@ -1,0 +1,278 @@
+/**
+ * Vault Deposits
+ *
+ * @module VaultDeposit
+ */
+
+import { Transaction } from '@mysten/sui/transactions'
+import type { TransactionObjectArgument } from '@mysten/sui/transactions'
+import { normalizeCoinType } from '@naviprotocol/lending'
+import { getVaultConfig, resolveVault } from './config'
+import { NaviVaultError } from './errors'
+import { findReceipts, getVaultLayout, selectHarvestableRules } from './layout'
+import { resolveDepositMarket } from './market'
+import { appendFreshnessPTB, createTxContext, depositPTB } from './ptb'
+import type { DepositArgs, VaultBuildOptions, VaultLayout } from './types'
+import { throwVaultError } from './errors'
+
+const SUI_COIN_TYPE = '0x2::sui::SUI'
+
+/**
+ * Throws when the vault cannot currently accept operations.
+ *
+ * Covers the two preconditions the contract enforces on every entrypoint — pause state
+ * and contract version. Checking version here matters: a vault left unmigrated after a
+ * package upgrade aborts `E_INCORRECT_VERSION` on every call, and without this the
+ * caller would pay gas to discover that.
+ */
+export function assertOperable(layout: VaultLayout, label: string, expectedVersion?: number): void {
+  if (layout.paused) {
+    throw new NaviVaultError({
+      code: 10011,
+      name: 'E_PAUSED',
+      kind: 'outage',
+      message: `${label} is unavailable: the vault is paused.`,
+      raw: 'paused'
+    })
+  }
+
+  if (expectedVersion !== undefined && layout.version !== BigInt(expectedVersion)) {
+    throw new NaviVaultError({
+      code: 10036,
+      name: 'E_INCORRECT_VERSION',
+      kind: 'outage',
+      message:
+        `${label} is unavailable: the vault object is at version ${layout.version} but the ` +
+        `configured package expects ${expectedVersion}. Either the vault has not been ` +
+        `migrated after a package upgrade, or the configured packageId is stale. Every ` +
+        `entrypoint aborts 10036 until they agree.`,
+      raw: `${layout.version} != ${expectedVersion}`
+    })
+  }
+}
+
+/** Sentinel for {@link DepositArgs.position} meaning "open a fresh position". */
+export const NEW_POSITION = 'new'
+
+/**
+ * Decides which receipt a deposit should credit.
+ *
+ * Reuses the sender's existing receipt when they hold exactly one, and returns
+ * `undefined` — mint a new one — when they hold none. Holding several is ambiguous: each
+ * receipt is a separate position, and silently topping one up is precisely what leaves
+ * stray empty receipts behind, so the caller is asked to choose.
+ *
+ * Costs one read (~60ms). Skipped entirely when the caller has already decided.
+ */
+export async function resolveDepositReceipt(
+  args: Pick<DepositArgs, 'vault' | 'sender' | 'position'>,
+  options?: VaultBuildOptions
+): Promise<string | undefined> {
+  if (args.position === NEW_POSITION) return undefined
+  if (args.position) return args.position
+
+  const receipts = await findReceipts(args.sender, args.vault, options)
+  if (receipts.length === 0) return undefined
+  if (receipts.length === 1) return receipts[0]!.objectId
+
+  throw new NaviVaultError({
+    code: 0,
+    name: 'AMBIGUOUS_RECEIPT',
+    kind: 'user',
+    message:
+      `The sender holds ${receipts.length} receipts on this vault, so which position to ` +
+      `credit is ambiguous. Pass position: '<receiptId>' to top one up, or ` +
+      `position: 'new' to open another. Receipts: ` +
+      `${receipts.map((receipt) => receipt.objectId).join(', ')}.`,
+    raw: receipts.map((receipt) => receipt.objectId).join(',')
+  })
+}
+
+/**
+ * Produces a coin argument holding exactly `amount`.
+ *
+ * The contract asserts `deposit_coin.value() == amount` and aborts `E_AMOUNT_MISMATCH`
+ * (10021) otherwise, so an approximate coin is never acceptable.
+ *
+ * For SUI this splits from the gas coin. For every other asset it gathers the owner's
+ * coin objects, merges them and splits — the owner's balance may be spread across many
+ * objects, and a single one is rarely large enough.
+ */
+export async function prepareDepositCoin(
+  tx: Transaction,
+  args: { owner: string; coinType: string; amount: bigint },
+  options?: VaultBuildOptions
+): Promise<TransactionObjectArgument> {
+  const coinType = normalizeCoinType(args.coinType)
+
+  if (coinType === normalizeCoinType(SUI_COIN_TYPE)) {
+    const [coin] = tx.splitCoins(tx.gas, [tx.pure.u64(args.amount)])
+    return coin as TransactionObjectArgument
+  }
+
+  const core = (options?.client as { core?: unknown } | undefined)?.core as
+    | {
+        listCoins?(input: unknown): Promise<{
+          objects: { objectId: string; balance: string }[]
+          cursor?: string | null
+          hasNextPage?: boolean
+        }>
+      }
+    | undefined
+
+  if (typeof core?.listCoins !== 'function') {
+    throw new Error(
+      `Depositing ${args.coinType} requires a Sui v2 Core-capable client to select coin objects, ` +
+        `or an explicit coin argument.`
+    )
+  }
+
+  const owned: { objectId: string; balance: bigint }[] = []
+  let total = 0n
+  let cursor: string | null | undefined
+
+  do {
+    let page
+    try {
+      page = await core.listCoins({ owner: args.owner, coinType, cursor })
+    } catch (error) {
+      throwVaultError(error)
+    }
+    for (const coin of page.objects) {
+      const balance = BigInt(coin.balance)
+      if (balance === 0n) continue
+      owned.push({ objectId: coin.objectId, balance })
+      total += balance
+    }
+    // Same guard as findReceipts: never re-request a cursor we just used.
+    const nextCursor = page.hasNextPage ? (page.cursor ?? null) : null
+    cursor = nextCursor && nextCursor !== cursor ? nextCursor : null
+  } while (cursor)
+
+  if (total < args.amount) {
+    throw new NaviVaultError({
+      code: 10002,
+      name: 'E_INSUFFICIENT_BALANCE',
+      kind: 'user',
+      message: `Owner holds ${total} of ${args.coinType}, needs ${args.amount}.`,
+      raw: `${total} < ${args.amount}`
+    })
+  }
+
+  const [primary, ...rest] = owned
+  if (!primary) {
+    throw new NaviVaultError({
+      code: 10002,
+      name: 'E_INSUFFICIENT_BALANCE',
+      kind: 'user',
+      message: `Owner holds no ${args.coinType} coin objects.`,
+      raw: '0'
+    })
+  }
+
+  const primaryArg = tx.object(primary.objectId)
+  if (rest.length > 0) {
+    tx.mergeCoins(
+      primaryArg,
+      rest.map((coin) => tx.object(coin.objectId))
+    )
+  }
+
+  const [coin] = tx.splitCoins(primaryArg, [tx.pure.u64(args.amount)])
+  return coin as TransactionObjectArgument
+}
+
+/**
+ * Builds a complete deposit transaction.
+ *
+ * The block is `M + R + 1` Move calls plus coin handling: every registered market
+ * synchronized, every active market reward rule harvested, then `deposit`. No oracle
+ * update is emitted — `logic::execute_deposit` takes no oracle and performs no price
+ * read.
+ *
+ * The layout is read at build time and must not be reused for a later transaction.
+ *
+ * Deposit headroom is the minimum of three bounds and only two are checked here: the
+ * third is NAVI's reserve supply ceiling, which is shared with every other participant
+ * in that reserve and can abort the deposit with 1604 while both vault and market caps
+ * still have room.
+ *
+ * The position credited is resolved by {@link resolveDepositReceipt}: the sender's
+ * existing receipt is topped up when they hold exactly one, and a new one is minted when
+ * they hold none. Pass `position` to decide explicitly and skip the lookup.
+ */
+export async function buildDepositTx(
+  args: DepositArgs,
+  options?: VaultBuildOptions
+): Promise<Transaction> {
+  const config = await getVaultConfig(options)
+  const descriptor = resolveVault(args.vault, config)
+  const layout = options?.layout ?? (await getVaultLayout(descriptor, options))
+  const ctx = createTxContext(config, descriptor)
+
+  assertOperable(layout, 'Deposit', config.package.expectedVaultVersion)
+
+  if (args.amount <= 0n) {
+    throw new NaviVaultError({
+      code: 10034,
+      name: 'E_INVALID_AMOUNT',
+      kind: 'user',
+      message: 'Deposit amount must be greater than zero.',
+      raw: String(args.amount)
+    })
+  }
+
+  // Cap checks are deliberately left to the contract. Both the vault cap and the market
+  // cap are compared against balances that are only refreshed by the sync commands this
+  // very block emits, so any figure available at build time is stale — pre-checking it
+  // here could reject a deposit that would in fact succeed. Use getVaultQuote for a
+  // synchronized headroom figure to show a user, and let E_CAP_EXCEEDED /
+  // E_VAULT_CAP_EXCEEDED be authoritative.
+  const market = resolveDepositMarket(layout)
+  if (!market) {
+    throw new NaviVaultError({
+      code: 10022,
+      name: 'E_DEFAULT_MARKET_MISMATCH',
+      kind: 'config',
+      message:
+        'The vault has no default market, so deposits would accumulate in the idle balance. ' +
+        'This SDK does not build idle-only deposits — confirm the vault configuration first.',
+      raw: layout.defaultMarket
+    })
+  }
+
+  // Resolved before the transaction is opened: reuse the sender's position when there is
+  // one, mint when there is none. Without this every deposit opens a new position and
+  // leaves the previous one behind.
+  const receiptId = await resolveDepositReceipt(args, options)
+
+  const tx = new Transaction()
+  tx.setSenderIfNotSet(args.sender)
+
+  appendFreshnessPTB(tx, ctx, layout, selectHarvestableRules(layout, descriptor))
+
+  const coin =
+    args.coin !== undefined
+      ? (tx.splitCoins(args.coin, [tx.pure.u64(args.amount)])[0] as TransactionObjectArgument)
+      : await prepareDepositCoin(
+          tx,
+          { owner: args.sender, coinType: descriptor.coinType, amount: args.amount },
+          options
+        )
+
+  const [receipt] = depositPTB(tx, ctx, {
+    market,
+    coin,
+    amount: args.amount,
+    receipt: receiptId ? tx.object(receiptId) : undefined
+  })
+
+  // The returned receipt is a hot potato — it must be consumed. When adding to an
+  // existing position the same object is handed straight back, so this returns it to
+  // its owner rather than creating anything new.
+  if (receipt) {
+    tx.transferObjects([receipt], tx.pure.address(args.sender))
+  }
+
+  return tx
+}

--- a/packages/vault/src/errors.ts
+++ b/packages/vault/src/errors.ts
@@ -1,0 +1,359 @@
+/**
+ * Vault Error Classification
+ *
+ * A vault transaction can abort from three different packages, and the codes overlap in
+ * meaning but not in remedy. `navi_vault` raises 10001–10042; `lending_core` and the
+ * oracle raise their own, and those are the ones most likely to be misreported as user
+ * error when they are not.
+ *
+ * @module VaultErrors
+ */
+
+/**
+ * What the caller should do about an abort.
+ *
+ * - `user` — the request itself is wrong. Fix the arguments.
+ * - `transient` — valid request, momentarily unsatisfiable. Retrying may work.
+ * - `liquidity` — the underlying reserve cannot release the assets right now. Route
+ *   elsewhere or wait.
+ * - `outage` — the operation is unavailable for reasons outside the caller's control.
+ *   Never present as user error. How far the unavailability reaches varies by code; the
+ *   per-code message says so (1400 halts everything, E_MARKET_INVALID only blocks
+ *   inflows).
+ * - `config` — the SDK's configuration disagrees with chain state.
+ * - `unknown` — unrecognized code.
+ */
+export type VaultErrorKind = 'user' | 'transient' | 'liquidity' | 'outage' | 'config' | 'unknown'
+
+/** A decoded abort. */
+export type VaultError = {
+  /** Numeric abort code. */
+  code: number
+  /** Move module that raised it, when recoverable from the message. */
+  module?: string
+  /** Stable symbolic name, e.g. `E_MARKET_NOT_READ`. */
+  name: string
+  kind: VaultErrorKind
+  /** What went wrong and what to do about it. */
+  message: string
+  /** Original error text. */
+  raw: string
+}
+
+type ErrorSpec = { name: string; kind: VaultErrorKind; message: string }
+
+/** navi_vault abort codes. Source: `sources/navi_vault.move`. */
+const VAULT_ERRORS: Record<number, ErrorSpec> = {
+  10001: { name: 'E_UNAUTHORIZED', kind: 'user', message: 'Caller lacks the required capability.' },
+  10002: {
+    name: 'E_INSUFFICIENT_BALANCE',
+    kind: 'user',
+    message:
+      'The vault or the holder does not hold enough to satisfy this amount. Distinct from reserve illiquidity (1506).'
+  },
+  10003: { name: 'E_MARKET_NOT_FOUND', kind: 'config', message: 'Market is not registered.' },
+  10004: {
+    name: 'E_TIMELOCK_NOT_EXPIRED',
+    kind: 'user',
+    message: 'The proposal is still inside its 24h timelock.'
+  },
+  10005: {
+    name: 'E_CAP_EXCEEDED',
+    kind: 'user',
+    message: 'Deposit would push the target market past its cap.'
+  },
+  10006: {
+    name: 'E_MARKET_NOT_READ',
+    kind: 'user',
+    message:
+      'A registered market was not synchronized in this transaction. Every market must be synced, Disabled ones included. Re-read the layout — market membership may have changed.'
+  },
+  10007: {
+    name: 'E_REWARDS_NOT_COLLECTED',
+    kind: 'user',
+    message:
+      'An active market reward rule was not harvested in this transaction. Re-read the layout, or check that the RewardFund object for the rule is configured.'
+  },
+  10008: { name: 'E_RECEIPT_NOT_FOUND', kind: 'user', message: 'No position for this receipt.' },
+  10009: {
+    name: 'E_VAULT_MISMATCH',
+    kind: 'user',
+    message: 'The receipt or capability belongs to a different vault.'
+  },
+  10010: {
+    // Classified as an outage, not user error: the caller cannot make a Disabled market
+    // accept a deposit. Withdrawals from it still work, so this blocks inflows only.
+    name: 'E_MARKET_INVALID',
+    kind: 'outage',
+    message:
+      'Target market is Disabled and cannot receive deposits or allocations. Withdrawals ' +
+      'from it are unaffected.'
+  },
+  10011: {
+    name: 'E_PAUSED',
+    kind: 'outage',
+    message: 'The vault is paused. All user operations are disabled.'
+  },
+  10012: {
+    name: 'E_DEPOSIT_TOO_SMALL',
+    kind: 'user',
+    message: 'Deposit would mint zero shares. Increase the amount.'
+  },
+  10013: { name: 'E_OVERFLOW', kind: 'user', message: 'Arithmetic overflow.' },
+  10014: { name: 'E_INVALID_PENALTY', kind: 'config', message: 'Penalty exceeds the 30% cap.' },
+  10015: {
+    name: 'E_ALLOCATOR_CAP_NOT_FOUND',
+    kind: 'user',
+    message: 'AllocatorCap not registered.'
+  },
+  10016: { name: 'E_PROPOSAL_NOT_FOUND', kind: 'user', message: 'No such timelock proposal.' },
+  10017: {
+    name: 'E_MARKET_CONFIG_MISMATCH',
+    kind: 'config',
+    message:
+      'A Storage or incentive object does not match what the vault has recorded for this market. Re-read the layout instead of using configured values.'
+  },
+  10018: {
+    name: 'E_TIMELOCK_EXPIRED',
+    kind: 'user',
+    message: 'The proposal passed its 7-day grace period.'
+  },
+  10019: { name: 'E_CURATOR_CAP_NOT_VALID', kind: 'user', message: 'CuratorCap was revoked.' },
+  10020: { name: 'E_CURATOR_CAP_NOT_FOUND', kind: 'user', message: 'CuratorCap not registered.' },
+  10021: {
+    name: 'E_AMOUNT_MISMATCH',
+    kind: 'user',
+    message:
+      'The deposit coin value does not equal the declared amount. Split to exactly the amount.'
+  },
+  10022: {
+    name: 'E_DEFAULT_MARKET_MISMATCH',
+    kind: 'user',
+    message:
+      "The pool argument is not the vault's default market. Deposits route only to the default market; so do withdrawals when fromDefault is set."
+  },
+  10023: {
+    name: 'E_PROPOSAL_ALREADY_EXISTS',
+    kind: 'user',
+    message: 'A proposal is already pending.'
+  },
+  10024: { name: 'E_PROPOSAL_NOOP', kind: 'user', message: 'The proposal would change nothing.' },
+  10025: { name: 'E_WRONG_PROPOSAL_TYPE', kind: 'user', message: 'Proposal type mismatch.' },
+  10026: { name: 'E_RULE_NOT_FOUND', kind: 'config', message: 'No such reward rule.' },
+  10027: { name: 'E_RULE_ALREADY_ACTIVE', kind: 'user', message: 'Reward rule is already active.' },
+  10028: {
+    name: 'E_RULE_ALREADY_INACTIVE',
+    kind: 'user',
+    message: 'Reward rule is already inactive.'
+  },
+  10029: {
+    name: 'E_REWARD_COIN_TYPE_MISMATCH',
+    kind: 'config',
+    message: "The RewardCoinType type argument does not match the rule's stored reward coin."
+  },
+  10030: {
+    name: 'E_RULE_INDEX_OUT_OF_BOUNDS',
+    kind: 'config',
+    message: 'Reward rule index is out of range.'
+  },
+  10031: {
+    name: 'E_FEE_OUT_OF_RANGE',
+    kind: 'user',
+    message: 'Fee exceeds its cap (20% mgmt / 40% perf).'
+  },
+  10032: { name: 'E_INVALID_STATUS', kind: 'user', message: 'Unknown market status discriminant.' },
+  10033: {
+    name: 'E_FEE_UNCHANGED',
+    kind: 'user',
+    message: 'The fee is already set to this value.'
+  },
+  10034: { name: 'E_INVALID_AMOUNT', kind: 'user', message: 'Amount must be greater than zero.' },
+  10035: {
+    name: 'E_MARKET_ALREADY_EXISTS',
+    kind: 'user',
+    message: 'Market is already registered.'
+  },
+  10036: {
+    name: 'E_INCORRECT_VERSION',
+    kind: 'outage',
+    message:
+      "The vault object's version does not match the deployed package. Distinct from lending_core's 1400 despite both originating in a module named `version`."
+  },
+  10037: {
+    name: 'E_VERSION_UPGRADE_NOT_NEEDED',
+    kind: 'user',
+    message: 'Vault is already migrated.'
+  },
+  10038: {
+    name: 'E_ACCOUNTING_ERROR',
+    kind: 'outage',
+    message: 'Vault internal accounting invariant violated.'
+  },
+  10039: {
+    name: 'E_VAULT_CAP_EXCEEDED',
+    kind: 'user',
+    message: 'Deposit would push the vault past its total cap.'
+  },
+  10040: {
+    name: 'E_SLIPPAGE_EXCEEDED',
+    kind: 'transient',
+    message:
+      'Shares burned exceeded maxShares. Re-simulate the withdrawal to derive a current bound.'
+  },
+  10041: {
+    name: 'E_CANNOT_DISABLE_DEFAULT_MARKET',
+    kind: 'user',
+    message: 'Cannot disable the default market.'
+  },
+  10042: {
+    name: 'E_WITHDRAW_EXCEEDS_UNDISTRIBUTED',
+    kind: 'user',
+    message: 'Withdrawal exceeds the undistributed reward balance.'
+  }
+}
+
+/**
+ * Aborts raised by packages the vault calls into. These are the ones most often
+ * misattributed: none of them means the caller's request was malformed.
+ */
+const EXTERNAL_ERRORS: Record<number, ErrorSpec> = {
+  1400: {
+    name: 'LENDING_INCORRECT_VERSION',
+    kind: 'outage',
+    message:
+      'The vault package is linked against a superseded lending_core. Every depositor operation aborts until the vault package itself is upgraded. Not recoverable client-side: no retry, gas or argument change works around it. Do not display a synced balance or accept deposits while it persists.'
+  },
+  1502: {
+    name: 'ORACLE_INVALID_PRICE',
+    kind: 'transient',
+    message:
+      "The oracle price for the vault's asset is outside its freshness window (30s by default). The withdrawal block must begin with a price update, before the market synchronizations."
+  },
+  1506: {
+    name: 'LENDING_INSUFFICIENT_BALANCE',
+    kind: 'liquidity',
+    message:
+      'The underlying NAVI reserve is too heavily utilized to release the assets. A property of the lending market, not of the vault, and transient. Routing to another market or drawing on the idle balance may succeed.'
+  },
+  1604: {
+    name: 'LENDING_EXCEEDED_DEPOSIT_CAP',
+    kind: 'liquidity',
+    message:
+      "The NAVI reserve's supply ceiling is reached. This bound is shared with every other participant in that reserve — including other vaults on the same market — so it can bind while the vault cap and market cap both have headroom."
+  }
+}
+
+/**
+ * Ordered from most to least specific.
+ *
+ * The `MoveAbort` pattern is greedy on purpose: a `MoveLocation` contains its own commas,
+ * parentheses and numbers (`function: 5, instruction: 42`), and the abort code is the
+ * last `, <digits>)` in the expression. A lazy match picks up an instruction offset
+ * instead and misclassifies the abort.
+ */
+const ABORT_CODE_PATTERNS = [
+  /MoveAbort\(.*,\s*(\d+)\s*\)/s,
+  /\babort_?[cC]ode"?\s*[:=]\s*"?(\d+)/,
+  /sub_status:?\s*(?:Some\()?(\d+)/i,
+  /abort(?:ed)?\s+(?:with\s+)?(?:code\s+)?(\d+)/i
+]
+
+function extractAbortCode(text: string): number | undefined {
+  for (const pattern of ABORT_CODE_PATTERNS) {
+    const match = text.match(pattern)
+    if (match?.[1]) {
+      return Number(match[1])
+    }
+  }
+  return undefined
+}
+
+function extractModule(text: string): string | undefined {
+  return text.match(/name:\s*Identifier\("([^"]+)"\)/)?.[1] ?? text.match(/::(\w+)::/)?.[1]
+}
+
+function toText(error: unknown): string {
+  if (typeof error === 'string') return error
+  if (error instanceof Error) return error.message
+  if (error && typeof error === 'object') {
+    const maybe = error as { message?: unknown; error?: unknown }
+    if (typeof maybe.message === 'string') return maybe.message
+    if (typeof maybe.error === 'string') return maybe.error
+    try {
+      return JSON.stringify(error)
+    } catch {
+      return String(error)
+    }
+  }
+  return String(error)
+}
+
+/**
+ * Decodes a Sui abort into a classified vault error.
+ *
+ * Accepts a thrown error, an error string, or a simulation result's `error` field.
+ * Returns `undefined` when the input carries no recognizable abort code — a network
+ * failure, for instance, which is not an abort at all.
+ */
+export function parseVaultError(error: unknown): VaultError | undefined {
+  const raw = toText(error)
+  if (!raw) return undefined
+
+  const code = extractAbortCode(raw)
+  if (code === undefined) return undefined
+
+  const module = extractModule(raw)
+  const spec = VAULT_ERRORS[code] ?? EXTERNAL_ERRORS[code]
+
+  if (!spec) {
+    return {
+      code,
+      module,
+      name: 'UNKNOWN_ABORT',
+      kind: 'unknown',
+      message: `Unrecognized abort code ${code}.`,
+      raw
+    }
+  }
+
+  return { code, module, name: spec.name, kind: spec.kind, message: spec.message, raw }
+}
+
+/**
+ * Wraps an abort in an Error carrying the decoded classification.
+ *
+ * Passes non-abort inputs through unchanged so that network and transport failures are
+ * not mislabeled as protocol conditions.
+ */
+export class NaviVaultError extends Error {
+  readonly code: number
+  readonly kind: VaultErrorKind
+  readonly abortName: string
+  readonly module?: string
+  readonly raw: string
+
+  constructor(decoded: VaultError) {
+    super(`[${decoded.name} / ${decoded.code}] ${decoded.message}`)
+    this.name = 'NaviVaultError'
+    this.code = decoded.code
+    this.kind = decoded.kind
+    this.abortName = decoded.name
+    this.module = decoded.module
+    this.raw = decoded.raw
+  }
+}
+
+/** Throws a classified {@link NaviVaultError} when `error` carries an abort code. */
+export function throwVaultError(error: unknown): never {
+  const decoded = parseVaultError(error)
+  if (decoded) throw new NaviVaultError(decoded)
+  throw error instanceof Error ? error : new Error(toText(error))
+}
+
+/**
+ * True when the condition is a protocol-level outage rather than anything the caller
+ * did. Callers should suppress balances and block deposits while this holds.
+ */
+export function isProtocolOutage(error: unknown): boolean {
+  return parseVaultError(error)?.kind === 'outage'
+}

--- a/packages/vault/src/index.ts
+++ b/packages/vault/src/index.ts
@@ -1,0 +1,122 @@
+/**
+ * Vault Package - Main Entry Point
+ *
+ * SDK for the NAVI Vault protocol on Sui: single-asset vaults that issue proportional
+ * shares and deploy the assets across NAVI lending markets.
+ *
+ * Two things distinguish this from a conventional SDK, and both are properties of the
+ * contract rather than choices made here:
+ *
+ * - **Deposits and withdrawals are multi-command blocks.** Every registered market must
+ *   be synchronized and every active market reward rule harvested in the same
+ *   transaction, so a deposit is `M + R + 1` Move calls. The `*PTB` functions emit
+ *   individual commands; the `build*Tx` functions assemble whole blocks.
+ * - **Prices come from simulation, not from reads.** A market position is a cached
+ *   figure refreshed only by an explicit call, and an inactive vault can carry a
+ *   month-old snapshot. Every pricing helper simulates a block that synchronizes first.
+ *
+ * @module Vault
+ */
+
+// Configuration, constants and vault resolution
+export {
+  configureVaultSdk,
+  getVault,
+  getVaultConfig,
+  isZeroAddress,
+  resolveVault,
+  MAX_U64,
+  RAY,
+  SECONDS_PER_YEAR,
+  VAULT_MODULE,
+  VIRTUAL_SHARES,
+  WAD,
+  ZERO_ADDRESS
+} from './config'
+
+// Bundled mainnet snapshot
+export { MAINNET_VAULT_CONFIG, SNAPSHOT_GENERATED_AT } from './snapshot'
+
+// Abort decoding and classification
+export { isProtocolOutage, NaviVaultError, parseVaultError, throwVaultError } from './errors'
+export type { VaultError, VaultErrorKind } from './errors'
+
+// BCS schemas
+export * from './bcs'
+
+// Live state discovery
+export {
+  diffLayoutAgainstConfig,
+  findReceipts,
+  getVaultLayout,
+  selectHarvestableRules
+} from './layout'
+
+// Market selection
+export {
+  findMarket,
+  getDefaultMarket,
+  marketDepositHeadroom,
+  resolveDepositMarket,
+  resolveMarket
+} from './market'
+
+// Oracle prologue
+export { appendOracleProloguePTB, toLendingOptions } from './oracle'
+
+// Low-level PTB command emitters
+export {
+  appendCollectRewardsPTB,
+  appendFreshnessPTB,
+  appendSyncMarketsPTB,
+  claimRewardPTB,
+  createReceiptPTB,
+  createTxContext,
+  depositPTB,
+  getClaimableRewardPTB,
+  getTotalAssetsPTB,
+  getUserBalancePTB,
+  getUserSharesPTB,
+  withdrawPTB
+} from './ptb'
+export type { VaultTxContext } from './ptb'
+
+// Pricing
+export { getVaultPositions, getVaultQuote, previewWithdraw, sharePrice } from './quote'
+export type { WithdrawPreview } from './quote'
+
+// Transaction builders
+export {
+  assertOperable,
+  buildDepositTx,
+  prepareDepositCoin,
+  resolveDepositReceipt,
+  NEW_POSITION
+} from './deposit'
+export { buildExitAllTx, buildWithdrawTx, buildWithdrawTxWithPreview } from './withdraw'
+export {
+  buildClaimRewardTx,
+  getRecordedClaimableReward,
+  getRewardCoinTypes,
+  previewClaimReward
+} from './reward'
+
+// Simulation and formatting helpers
+export {
+  decode,
+  decodeCommand,
+  decodeOne,
+  estimateGas,
+  formatUnits,
+  isSameAddress,
+  normalizeAddress,
+  normalizeMoveType,
+  simulate,
+  tryDecodeCoinBalance,
+  wadToPercent,
+  SIMULATION_SENDER
+} from './utils'
+export type { Decoder, GasEstimate, RawCommandReturn } from './utils'
+
+// Types
+export * from './types'

--- a/packages/vault/src/layout.ts
+++ b/packages/vault/src/layout.ts
@@ -1,0 +1,431 @@
+/**
+ * Vault Layout Discovery
+ *
+ * Reads live vault state — market membership, reward rules, fees, pause state — from
+ * chain, and locates a holder's receipts.
+ *
+ * Results must NOT be cached across transactions. `add_market` registers a market with
+ * `lastSyncAtMs = 0n` and `set_loss` resets an existing one, so a transaction built from
+ * a stale layout aborts with `E_MARKET_NOT_READ` (10006). Read the layout while building
+ * the transaction that uses it.
+ *
+ * @command budget: two simulated round trips — one to learn the market and rule counts,
+ * one to read them.
+ *
+ * @module VaultLayout
+ */
+
+import { Transaction } from '@mysten/sui/transactions'
+import { getVaultConfig, isZeroAddress, resolveVault, VAULT_MODULE } from './config'
+import { NaviVaultError, throwVaultError } from './errors'
+import { ReceiptStruct } from './bcs'
+import type {
+  HarvestableRule,
+  VaultDescriptor,
+  VaultIdentifier,
+  VaultLayout,
+  VaultReadOptions,
+  VaultReceipt
+} from './types'
+import { MarketStatus } from './types'
+import {
+  decode,
+  decodeCommand,
+  decodeOne,
+  isSameAddress,
+  normalizeAddress,
+  normalizeMoveType,
+  simulate
+} from './utils'
+
+/** Number of commands emitted per market by the layout read block. */
+const COMMANDS_PER_MARKET = 3
+
+/**
+ * Return schemas, taken from the contract signatures in `sources/navi_vault.move`.
+ * The simulation response carries no type information, so these are the only thing
+ * defining how the bytes are read.
+ */
+const SCHEMA = {
+  /** `(cap, penalty, loss, status, last_sync_at, storage, asset_id, incentive_v3, incentive_v2)` */
+  marketConfig: [
+    decode.u64,
+    decode.u64,
+    decode.u64,
+    decode.u8,
+    decode.u64,
+    decode.address,
+    decode.u8,
+    decode.address,
+    decode.address
+  ],
+  /**
+   * `(navi_pool_id, reward_coin_type, incentive_rule_id, vault_reward_index,
+   *   last_harvest_at, is_vault_native, reward_rate, is_active,
+   *   total_reward_deposited, total_reward_distributed)`
+   */
+  ruleInfo: [
+    decode.address,
+    decode.string,
+    decode.address,
+    decode.u256,
+    decode.u64,
+    decode.bool,
+    decode.u256,
+    decode.bool,
+    decode.u64,
+    decode.u64
+  ]
+} as const
+
+function target(packageId: string, fn: string): `${string}::${string}::${string}` {
+  return `${packageId}::${VAULT_MODULE}::${fn}`
+}
+
+function marketStatusFromDiscriminant(value: number): MarketStatus {
+  if (value === MarketStatus.Active) return MarketStatus.Active
+  if (value === MarketStatus.Disabled) return MarketStatus.Disabled
+  throw new Error(`Unknown market status discriminant: ${value}`)
+}
+
+/**
+ * Reads the vault's live layout.
+ *
+ * @param identifier - Vault object id, config key, or descriptor.
+ */
+export async function getVaultLayout(
+  identifier: VaultIdentifier,
+  options?: VaultReadOptions
+): Promise<VaultLayout> {
+  const config = await getVaultConfig(options)
+  const descriptor = resolveVault(identifier, config)
+  const { packageId } = config.package
+  const typeArgs = [descriptor.coinType]
+
+  // Round 1: scalars, plus the counts that size round 2.
+  const counts = new Transaction()
+  for (const fn of [
+    'num_markets',
+    'num_reward_rules',
+    'get_vault_default_market',
+    'is_paused',
+    'version',
+    'get_vault_cap',
+    'get_management_fee',
+    'get_performance_fee',
+    'get_idle_balance',
+    'get_total_shares'
+  ]) {
+    counts.moveCall({
+      target: target(packageId, fn),
+      typeArguments: typeArgs,
+      arguments: [counts.object(descriptor.vault)]
+    })
+  }
+
+  const scalars = await simulate(counts, options)
+  const marketCount = Number(decodeOne(scalars, 0, decode.u64, 'num_markets'))
+  const ruleCount = Number(decodeOne(scalars, 1, decode.u64, 'num_reward_rules'))
+
+  const layout: VaultLayout = {
+    markets: [],
+    rules: [],
+    defaultMarket: normalizeAddress(
+      decodeOne(scalars, 2, decode.address, 'get_vault_default_market')
+    ),
+    paused: decodeOne(scalars, 3, decode.bool, 'is_paused'),
+    version: decodeOne(scalars, 4, decode.u64, 'version'),
+    vaultCap: decodeOne(scalars, 5, decode.u64, 'get_vault_cap'),
+    managementFee: decodeOne(scalars, 6, decode.u64, 'get_management_fee'),
+    performanceFee: decodeOne(scalars, 7, decode.u64, 'get_performance_fee'),
+    idleBalance: decodeOne(scalars, 8, decode.u64, 'get_idle_balance'),
+    totalShares: decodeOne(scalars, 9, decode.u64, 'get_total_shares')
+  }
+
+  if (marketCount === 0 && ruleCount === 0) {
+    return layout
+  }
+
+  // Round 2: per-market config, then per-rule info. The pool address returned by
+  // get_market_address_at_index feeds the two reads that follow it, so the whole
+  // enumeration fits in one block.
+  const details = new Transaction()
+  for (let index = 0; index < marketCount; index += 1) {
+    const address = details.moveCall({
+      target: target(packageId, 'get_market_address_at_index'),
+      typeArguments: typeArgs,
+      arguments: [details.object(descriptor.vault), details.pure.u64(index)]
+    })
+    details.moveCall({
+      target: target(packageId, 'get_market_config'),
+      typeArguments: typeArgs,
+      arguments: [details.object(descriptor.vault), address]
+    })
+    details.moveCall({
+      target: target(packageId, 'get_market_info'),
+      typeArguments: typeArgs,
+      arguments: [details.object(descriptor.vault), address]
+    })
+  }
+  for (let index = 0; index < ruleCount; index += 1) {
+    details.moveCall({
+      target: target(packageId, 'get_rule_info'),
+      typeArguments: typeArgs,
+      arguments: [details.object(descriptor.vault), details.pure.u64(index)]
+    })
+  }
+
+  const results = await simulate(details, options)
+
+  for (let index = 0; index < marketCount; index += 1) {
+    const base = index * COMMANDS_PER_MARKET
+    const poolId = normalizeAddress(
+      decodeOne(results, base, decode.address, `market[${index}] address`)
+    )
+    const [
+      cap,
+      penalty,
+      loss,
+      status,
+      lastSyncAtMs,
+      storageId,
+      assetId,
+      incentiveV3Id,
+      incentiveV2Id
+    ] = decodeCommand(results, base + 1, SCHEMA.marketConfig, `market[${index}] config`)
+
+    layout.markets.push({
+      poolId,
+      cap,
+      penalty,
+      loss,
+      status: marketStatusFromDiscriminant(status),
+      lastSyncAtMs,
+      storageId: normalizeAddress(storageId),
+      assetId,
+      incentiveV3Id: normalizeAddress(incentiveV3Id),
+      incentiveV2Id: normalizeAddress(incentiveV2Id),
+      currentBalance: decodeOne(results, base + 2, decode.u64, `market[${index}] balance`)
+    })
+  }
+
+  const ruleBase = marketCount * COMMANDS_PER_MARKET
+  for (let index = 0; index < ruleCount; index += 1) {
+    const [
+      naviPoolId,
+      rewardCoinType,
+      incentiveRuleId,
+      vaultRewardIndex,
+      lastHarvestAtMs,
+      isVaultNative,
+      rewardRate,
+      isActive,
+      totalRewardDeposited,
+      totalRewardDistributed
+    ] = decodeCommand(results, ruleBase + index, SCHEMA.ruleInfo, `rule[${index}]`)
+
+    layout.rules.push({
+      index,
+      naviPoolId: normalizeAddress(naviPoolId),
+      // type_name renders addresses without the 0x prefix; unprefixed it is rejected
+      // as a type argument by the transport before it ever reaches the VM.
+      rewardCoinType: normalizeMoveType(rewardCoinType),
+      incentiveRuleId: normalizeAddress(incentiveRuleId),
+      vaultRewardIndex,
+      lastHarvestAtMs,
+      isVaultNative,
+      rewardRate,
+      isActive,
+      totalRewardDeposited,
+      totalRewardDistributed
+    })
+  }
+
+  return layout
+}
+
+/**
+ * Selects the rules that must be harvested in the same block as a deposit or withdrawal
+ * — active market rules only; vault-native rules settle internally and are exempt.
+ *
+ * Resolves each rule's `RewardFund`, `Storage` and `incentive_v3` objects from
+ * configuration, since they are not recorded in vault state. A rule whose fund cannot be
+ * resolved is fatal, not skippable: leaving it unharvested makes the following deposit or
+ * withdrawal abort with `E_REWARDS_NOT_COLLECTED`.
+ */
+export function selectHarvestableRules(
+  layout: VaultLayout,
+  descriptor: VaultDescriptor
+): HarvestableRule[] {
+  const harvestable = layout.rules.filter((rule) => rule.isActive && !rule.isVaultNative)
+
+  return harvestable.map((rule) => {
+    const configured = descriptor.rewardRules.find((candidate) => candidate.index === rule.index)
+    const rewardFund = configured?.rewardFund
+    const storageId = configured?.storage
+    const incentiveV3Id = configured?.incentiveV3
+
+    if (!rewardFund || !storageId || !incentiveV3Id) {
+      throw new NaviVaultError({
+        code: 10007,
+        name: 'E_REWARDS_NOT_COLLECTED',
+        kind: 'config',
+        message:
+          `Reward rule ${rule.index} (${rule.rewardCoinType}) is active on chain but has no ` +
+          `RewardFund/Storage/incentive_v3 in configuration. RewardFund objects live on the ` +
+          `lending side and are not discoverable from vault state — add them to the vault ` +
+          `config, otherwise every deposit and withdrawal on this vault will abort.`,
+        raw: `rule ${rule.index}`
+      })
+    }
+
+    return { ...rule, rewardFund, storageId, incentiveV3Id }
+  })
+}
+
+/**
+ * Cross-checks the live layout against configuration and returns human-readable
+ * discrepancies.
+ *
+ * A non-empty result means the bundled or supplied config has drifted from chain and
+ * transactions built from it may abort. Markets are compared by pool id; a market present
+ * on chain but absent from config is the case that breaks deposits, because its
+ * `Storage` object cannot be resolved for the required synchronization.
+ */
+export function diffLayoutAgainstConfig(
+  layout: VaultLayout,
+  descriptor: VaultDescriptor
+): string[] {
+  const issues: string[] = []
+
+  for (const market of layout.markets) {
+    const configured = descriptor.markets.find((candidate) =>
+      isSameAddress(candidate.pool, market.poolId)
+    )
+    if (!configured) {
+      issues.push(`Market ${market.poolId} is registered on chain but missing from configuration.`)
+      continue
+    }
+    if (!isSameAddress(configured.storage, market.storageId)) {
+      issues.push(
+        `Market ${configured.name}: configured Storage ${configured.storage} does not match ` +
+          `on-chain ${market.storageId}.`
+      )
+    }
+    if (!isSameAddress(configured.incentiveV3, market.incentiveV3Id)) {
+      issues.push(
+        `Market ${configured.name}: configured incentive_v3 ${configured.incentiveV3} does not ` +
+          `match on-chain ${market.incentiveV3Id}.`
+      )
+    }
+    if (configured.assetId !== market.assetId) {
+      issues.push(
+        `Market ${configured.name}: configured assetId ${configured.assetId} does not match ` +
+          `on-chain ${market.assetId}.`
+      )
+    }
+  }
+
+  for (const configured of descriptor.markets) {
+    if (!layout.markets.some((market) => isSameAddress(market.poolId, configured.pool))) {
+      issues.push(
+        `Market ${configured.name} (${configured.pool}) is in configuration but not registered ` +
+          `on chain.`
+      )
+    }
+  }
+
+  const configuredDefault = descriptor.markets.find((market) => market.isDefault)
+  if (
+    !isZeroAddress(layout.defaultMarket) &&
+    configuredDefault &&
+    !isSameAddress(configuredDefault.pool, layout.defaultMarket)
+  ) {
+    issues.push(
+      `Default market changed: configuration says ${configuredDefault.name} ` +
+        `(${configuredDefault.pool}), chain says ${layout.defaultMarket}.`
+    )
+  }
+
+  for (const rule of layout.rules) {
+    if (!rule.isActive || rule.isVaultNative) continue
+    const configured = descriptor.rewardRules.find((candidate) => candidate.index === rule.index)
+    if (!configured?.rewardFund) {
+      issues.push(
+        `Reward rule ${rule.index} (${rule.rewardCoinType}) is active on chain but has no ` +
+          `RewardFund in configuration.`
+      )
+    }
+  }
+
+  return issues
+}
+
+/**
+ * Lists a holder's positions in one vault.
+ *
+ * Two properties of `Receipt` make this less direct than it looks. It is not generic, so
+ * one type covers every vault and each object's `vault_address` has to be matched
+ * individually — this is load-bearing, not defensive: two vaults share `0x2::sui::SUI`
+ * and two more share USDC. And the type filter must use the ORIGINAL package id, never
+ * the current call target; the wrong one matches nothing and reports no error.
+ */
+export async function findReceipts(
+  owner: string,
+  identifier: VaultIdentifier,
+  options?: VaultReadOptions
+): Promise<VaultReceipt[]> {
+  const config = await getVaultConfig(options)
+  const descriptor = resolveVault(identifier, config)
+  const receiptType = `${config.package.typePackageId}::${VAULT_MODULE}::Receipt`
+
+  const core = (options?.client as { core?: unknown } | undefined)?.core as
+    | {
+        listOwnedObjects?(input: unknown): Promise<{
+          objects: { objectId: string; content?: Uint8Array | null }[]
+          cursor?: string | null
+          hasNextPage?: boolean
+        }>
+      }
+    | undefined
+
+  if (typeof core?.listOwnedObjects !== 'function') {
+    throw new Error('findReceipts requires a Sui v2 Core-capable client')
+  }
+
+  const vaultAddress = normalizeAddress(descriptor.vault)
+  const receipts: VaultReceipt[] = []
+  let cursor: string | null | undefined
+
+  do {
+    let page
+    try {
+      page = await core.listOwnedObjects({
+        owner,
+        type: receiptType,
+        cursor,
+        include: { content: true }
+      })
+    } catch (error) {
+      throwVaultError(error)
+    }
+
+    for (const object of page.objects) {
+      if (!object.content) continue
+      const parsed = ReceiptStruct.parse(Uint8Array.from(object.content))
+      if (normalizeAddress(parsed.vault_address) !== vaultAddress) continue
+      receipts.push({
+        objectId: normalizeAddress(object.objectId),
+        vaultAddress
+      })
+    }
+
+    // Guard the loop rather than trusting hasNextPage alone: a transport that reports
+    // another page but returns no cursor, or repeats the one we sent, would otherwise
+    // re-fetch the same page forever.
+    const nextCursor = page.hasNextPage ? (page.cursor ?? null) : null
+    cursor = nextCursor && nextCursor !== cursor ? nextCursor : null
+  } while (cursor)
+
+  return receipts
+}

--- a/packages/vault/src/market.ts
+++ b/packages/vault/src/market.ts
@@ -1,0 +1,140 @@
+/**
+ * Vault Market Selection
+ *
+ * Resolves which registered market a deposit or withdrawal should be pointed at.
+ *
+ * @module VaultMarket
+ */
+
+import { isZeroAddress } from './config'
+import { NaviVaultError } from './errors'
+import type { MarketLayout, VaultLayout } from './types'
+import { MarketStatus } from './types'
+import { isSameAddress } from './utils'
+
+/** Finds a market by pool id, in any address padding. */
+export function findMarket(layout: VaultLayout, poolId: string): MarketLayout | undefined {
+  return layout.markets.find((market) => isSameAddress(market.poolId, poolId))
+}
+
+/**
+ * Returns the vault's deposit routing target, or `undefined` when unset.
+ *
+ * An unset default market (`0x0`) means deposits accumulate in the idle balance rather
+ * than being forwarded into NAVI. The pool argument is still type-required in that case
+ * but is neither validated nor used for routing.
+ */
+export function getDefaultMarket(layout: VaultLayout): MarketLayout | undefined {
+  if (isZeroAddress(layout.defaultMarket)) return undefined
+  return findMarket(layout, layout.defaultMarket)
+}
+
+/**
+ * Resolves the market to use for a withdrawal's shortfall.
+ *
+ * With `fromDefault`, the contract requires the default market and applies no penalty.
+ * Without it, any registered market may be drawn from — Disabled included, since market
+ * status is not checked on withdrawal, so a market being wound down stays drainable —
+ * and that market's penalty applies to the portion actually taken from it.
+ */
+export function resolveMarket(
+  layout: VaultLayout,
+  args: { fromDefault: boolean; poolId?: string }
+): MarketLayout {
+  if (args.fromDefault) {
+    const market = getDefaultMarket(layout)
+    if (!market) {
+      throw new NaviVaultError({
+        code: 10022,
+        name: 'E_DEFAULT_MARKET_MISMATCH',
+        kind: 'config',
+        message:
+          'fromDefault was requested but the vault has no default market set. Pass an explicit ' +
+          'poolId with fromDefault disabled, or draw on the idle balance.',
+        raw: layout.defaultMarket
+      })
+    }
+    if (args.poolId && !isSameAddress(args.poolId, market.poolId)) {
+      throw new NaviVaultError({
+        code: 10022,
+        name: 'E_DEFAULT_MARKET_MISMATCH',
+        kind: 'user',
+        message:
+          `fromDefault requires the default market (${market.poolId}), but ${args.poolId} was ` +
+          `given. Disable fromDefault to withdraw from a non-default market — note that it ` +
+          `applies that market's penalty.`,
+        raw: args.poolId
+      })
+    }
+    return market
+  }
+
+  if (!args.poolId) {
+    const fallback = getDefaultMarket(layout) ?? layout.markets[0]
+    if (!fallback) {
+      throw new NaviVaultError({
+        code: 10003,
+        name: 'E_MARKET_NOT_FOUND',
+        kind: 'config',
+        message: 'The vault has no registered markets.',
+        raw: ''
+      })
+    }
+    return fallback
+  }
+
+  const market = findMarket(layout, args.poolId)
+  if (!market) {
+    throw new NaviVaultError({
+      code: 10003,
+      name: 'E_MARKET_NOT_FOUND',
+      kind: 'user',
+      message:
+        `Market ${args.poolId} is not registered on this vault. Registered: ` +
+        `${layout.markets.map((entry) => entry.poolId).join(', ') || '(none)'}.`,
+      raw: args.poolId
+    })
+  }
+  return market
+}
+
+/**
+ * Resolves the market a deposit must be routed to.
+ *
+ * Deposits go only to the default market — any other pool aborts
+ * `E_DEFAULT_MARKET_MISMATCH` (10022) — and it must be Active.
+ *
+ * Returns `undefined` when no default market is set, meaning the deposit accumulates in
+ * the idle balance. The caller must still supply some registered market's objects to
+ * satisfy the signature.
+ */
+export function resolveDepositMarket(layout: VaultLayout): MarketLayout | undefined {
+  const market = getDefaultMarket(layout)
+  if (!market) return undefined
+
+  if (market.status !== MarketStatus.Active) {
+    throw new NaviVaultError({
+      code: 10010,
+      name: 'E_MARKET_INVALID',
+      kind: 'outage',
+      message:
+        `The vault's default market ${market.poolId} is Disabled and cannot receive deposits. ` +
+        `Withdrawals from it still work.`,
+      raw: market.poolId
+    })
+  }
+  return market
+}
+
+/**
+ * Remaining headroom on a market's own cap, in native decimals, or `null` when uncapped.
+ *
+ * This is one of three bounds on a deposit. The others are the vault cap and NAVI's
+ * reserve supply ceiling, the last of which is shared with every other participant in
+ * that reserve — including other vaults registered on the same market — and cannot be
+ * derived from vault state at all.
+ */
+export function marketDepositHeadroom(market: MarketLayout): bigint | null {
+  if (market.cap === 0n) return null
+  return market.cap > market.currentBalance ? market.cap - market.currentBalance : 0n
+}

--- a/packages/vault/src/oracle.ts
+++ b/packages/vault/src/oracle.ts
@@ -1,0 +1,88 @@
+/**
+ * Vault Oracle Prologue
+ *
+ * `withdraw` and `deallocate` reach NAVI's collateral valuation, which asserts price
+ * validity even though a vault holds no debt. A price is valid only while
+ * `now - price.timestamp <= PriceOracle.update_interval`, 30 seconds by default, and the
+ * vault receives `PriceOracle` by immutable reference so it cannot refresh it. Every
+ * withdrawal block must therefore open with a price update, before the market
+ * synchronizations, or abort 1502.
+ *
+ * The oracle entrypoint is versioned and its revisions accept different Pyth
+ * `PriceInfoObject` types, so it is deliberately not hardcoded here. This module
+ * delegates to `@naviprotocol/lending`, which resolves the entrypoint name and every
+ * oracle object from NAVI's configuration service — meaning an oracle upgrade is picked
+ * up without an SDK release.
+ *
+ * @module VaultOracle
+ */
+
+import type { Transaction } from '@mysten/sui/transactions'
+import { getPriceFeeds, normalizeCoinType, updateOraclePricesPTB } from '@naviprotocol/lending'
+import type { VaultBuildOptions, VaultDescriptor } from './types'
+
+/** The only option keys `@naviprotocol/lending` understands. */
+const LENDING_OPTION_KEYS = [
+  'client',
+  'env',
+  'services',
+  'market',
+  'markets',
+  'cacheTime',
+  'disableCache'
+] as const
+
+/**
+ * Narrows vault options to the subset lending accepts.
+ *
+ * This is not tidiness. Lending's cached entrypoints derive their cache key with
+ * `JSON.stringify` over the argument list, and `JSON.stringify` throws outright on a
+ * BigInt. Forwarding a vault options object wholesale passes `layout` — every amount in
+ * which is a BigInt — straight into that key and fails with
+ * "Do not know how to serialize a BigInt", from inside lending, nowhere near the call
+ * site. Anything handed to a lending function goes through here first.
+ */
+export function toLendingOptions(options?: VaultBuildOptions): Record<string, unknown> | undefined {
+  if (!options) return undefined
+  const narrowed: Record<string, unknown> = {}
+  for (const key of LENDING_OPTION_KEYS) {
+    const value = (options as Record<string, unknown>)[key]
+    if (value !== undefined) narrowed[key] = value
+  }
+  return narrowed
+}
+
+/**
+ * Appends the oracle price update for a vault's underlying asset.
+ *
+ * Emit this first — before the market synchronizations — in any block containing
+ * `withdraw`. Deposits take no oracle and must not include it.
+ *
+ * The refresh is per asset: updating an unrelated asset does not satisfy the assertion.
+ *
+ * @param updatePythPriceFeeds - Also refresh the Pyth feed on chain when it is stale.
+ *   Costs an extra call and a fee coin, but the 30-second window is short enough that
+ *   relying on another party to have refreshed it is not a strategy.
+ */
+export async function appendOracleProloguePTB(
+  tx: Transaction,
+  descriptor: VaultDescriptor,
+  options?: VaultBuildOptions & { updatePythPriceFeeds?: boolean }
+): Promise<Transaction> {
+  const lendingOptions = toLendingOptions(options)
+  const feeds = await getPriceFeeds(lendingOptions)
+  const coinType = normalizeCoinType(descriptor.coinType)
+  const matching = feeds.filter((feed) => normalizeCoinType(feed.coinType) === coinType)
+
+  if (matching.length === 0) {
+    throw new Error(
+      `No oracle price feed configured for ${descriptor.coinType}. Withdrawals from ` +
+        `${descriptor.displayName} will abort 1502 without one.`
+    )
+  }
+
+  return updateOraclePricesPTB(tx, matching, {
+    ...lendingOptions,
+    updatePythPriceFeeds: options?.updatePythPriceFeeds ?? true
+  })
+}

--- a/packages/vault/src/ptb.ts
+++ b/packages/vault/src/ptb.ts
@@ -1,0 +1,317 @@
+/**
+ * Vault PTB Builders
+ *
+ * Low-level, synchronous command emitters. Each appends Move calls to a transaction and
+ * performs no network I/O, so the caller controls exactly what a block contains.
+ *
+ * Unlike a single-call protocol, a vault deposit or withdrawal is `M + R + 1` commands:
+ * every registered market must be synchronized and every active market reward rule
+ * harvested in the *same* transaction, because the contract asserts they were refreshed
+ * at the current `clock.timestamp_ms()`. {@link appendFreshnessPTB} emits that prologue;
+ * the async builders in `deposit.ts` / `withdraw.ts` wrap all of it.
+ *
+ * Object ids for markets come from the layout, not from configuration — the contract
+ * validates them against what it has recorded and aborts `E_MARKET_CONFIG_MISMATCH`
+ * (10017) on any divergence.
+ *
+ * @module VaultPtb
+ */
+
+import type { Transaction, TransactionObjectArgument } from '@mysten/sui/transactions'
+import { VAULT_MODULE } from './config'
+import type {
+  HarvestableRule,
+  MarketLayout,
+  VaultConfig,
+  VaultDescriptor,
+  VaultLayout
+} from './types'
+
+/** Everything the PTB builders need that is not on the transaction itself. */
+export type VaultTxContext = {
+  /** LATEST package id — the moveCall target. */
+  packageId: string
+  /** ORIGINAL package id — used for the `Receipt` type argument. */
+  typePackageId: string
+  descriptor: VaultDescriptor
+  sharedObjects: VaultConfig['sharedObjects']
+}
+
+/** Builds a {@link VaultTxContext} from a resolved config and descriptor. */
+export function createTxContext(config: VaultConfig, descriptor: VaultDescriptor): VaultTxContext {
+  return {
+    packageId: config.package.packageId,
+    typePackageId: config.package.typePackageId,
+    descriptor,
+    sharedObjects: config.sharedObjects
+  }
+}
+
+function target(packageId: string, fn: string): `${string}::${string}::${string}` {
+  return `${packageId}::${VAULT_MODULE}::${fn}`
+}
+
+function receiptType(ctx: VaultTxContext): string {
+  return `${ctx.typePackageId}::${VAULT_MODULE}::Receipt`
+}
+
+/**
+ * Appends one `sync_market_balance` per registered market.
+ *
+ * Every market must be included, Disabled ones too: they remain part of assets under
+ * management and remain withdrawable, so omitting one aborts `E_MARKET_NOT_READ` (10006).
+ */
+export function appendSyncMarketsPTB(
+  tx: Transaction,
+  ctx: VaultTxContext,
+  layout: VaultLayout
+): Transaction {
+  for (const market of layout.markets) {
+    tx.moveCall({
+      target: target(ctx.packageId, 'sync_market_balance'),
+      typeArguments: [ctx.descriptor.coinType],
+      arguments: [
+        tx.object(ctx.descriptor.vault),
+        tx.object(market.storageId),
+        tx.object(market.poolId),
+        tx.object(ctx.sharedObjects.clock)
+      ]
+    })
+  }
+  return tx
+}
+
+/**
+ * Appends one `collect_reward` per harvestable rule.
+ *
+ * Pass the output of `selectHarvestableRules`. Vault-native and inactive rules are
+ * excluded there: the contract returns from `collect_reward` without effect for those —
+ * including without updating `last_harvest_at` — so calling them is harmless but pure
+ * wasted gas.
+ */
+export function appendCollectRewardsPTB(
+  tx: Transaction,
+  ctx: VaultTxContext,
+  rules: HarvestableRule[]
+): Transaction {
+  for (const rule of rules) {
+    tx.moveCall({
+      target: target(ctx.packageId, 'collect_reward'),
+      typeArguments: [ctx.descriptor.coinType, rule.rewardCoinType],
+      arguments: [
+        tx.object(ctx.descriptor.vault),
+        tx.object(ctx.sharedObjects.clock),
+        tx.object(rule.storageId),
+        tx.object(rule.incentiveV3Id),
+        tx.object(rule.rewardFund),
+        tx.pure.u64(rule.index)
+      ]
+    })
+  }
+  return tx
+}
+
+/**
+ * Appends the full freshness prologue: every market synchronized, then every active
+ * market rule harvested.
+ *
+ * Required before `deposit` and `withdraw`. Not required before `claim_reward`.
+ */
+export function appendFreshnessPTB(
+  tx: Transaction,
+  ctx: VaultTxContext,
+  layout: VaultLayout,
+  rules: HarvestableRule[]
+): Transaction {
+  appendSyncMarketsPTB(tx, ctx, layout)
+  appendCollectRewardsPTB(tx, ctx, rules)
+  return tx
+}
+
+/**
+ * Appends `deposit` and returns its `(Receipt, shares)` results.
+ *
+ * The freshness prologue must already be on the transaction. The returned receipt is a
+ * hot potato — it must be consumed by the block, normally transferred to the depositor.
+ *
+ * @param coin - Coin argument whose value must equal `amount` exactly, otherwise the
+ *   call aborts `E_AMOUNT_MISMATCH` (10021). Split it beforehand.
+ * @param receipt - Existing receipt to add to, or `undefined` to mint a new one.
+ */
+export function depositPTB(
+  tx: Transaction,
+  ctx: VaultTxContext,
+  args: {
+    market: MarketLayout
+    coin: TransactionObjectArgument
+    amount: bigint
+    receipt?: TransactionObjectArgument
+  }
+): TransactionObjectArgument[] {
+  const option = args.receipt
+    ? tx.moveCall({
+        target: '0x1::option::some',
+        typeArguments: [receiptType(ctx)],
+        arguments: [args.receipt]
+      })
+    : tx.moveCall({
+        target: '0x1::option::none',
+        typeArguments: [receiptType(ctx)]
+      })
+
+  return tx.moveCall({
+    target: target(ctx.packageId, 'deposit'),
+    typeArguments: [ctx.descriptor.coinType],
+    arguments: [
+      tx.object(ctx.descriptor.vault),
+      option,
+      tx.object(ctx.sharedObjects.clock),
+      tx.object(args.market.storageId),
+      tx.object(args.market.poolId),
+      args.coin,
+      tx.pure.u64(args.amount),
+      tx.object(ctx.sharedObjects.incentiveV2),
+      tx.object(args.market.incentiveV3Id)
+    ]
+  })
+}
+
+/**
+ * Appends `withdraw` and returns its `(Coin, sharesBurned)` results.
+ *
+ * The freshness prologue must already be on the transaction, and — unlike deposit — an
+ * oracle price update must precede it, because `withdraw` reaches NAVI's collateral
+ * valuation and takes `PriceOracle` by immutable reference so it cannot refresh the
+ * price itself. Without it the call aborts 1502.
+ *
+ * @param market - Source of the shortfall after the idle balance is drawn down. When
+ *   idle covers the full amount this argument is not validated and no penalty applies.
+ * @param maxShares - Upper bound on shares burned. `0n` skips the check entirely — it
+ *   means "no limit", not "no shares".
+ * @param fromDefault - When true, `market` must be the default market, no penalty
+ *   applies, and `amount` is clamped to the holder's maximum redeemable value, so
+ *   `MAX_U64` requests a full exit.
+ */
+export function withdrawPTB(
+  tx: Transaction,
+  ctx: VaultTxContext,
+  args: {
+    market: MarketLayout
+    receipt: TransactionObjectArgument
+    amount: bigint
+    maxShares: bigint
+    fromDefault: boolean
+  }
+): TransactionObjectArgument[] {
+  return tx.moveCall({
+    target: target(ctx.packageId, 'withdraw'),
+    typeArguments: [ctx.descriptor.coinType],
+    arguments: [
+      tx.object(ctx.descriptor.vault),
+      args.receipt,
+      tx.object(ctx.sharedObjects.clock),
+      tx.object(ctx.sharedObjects.priceOracle),
+      tx.object(args.market.storageId),
+      tx.object(args.market.poolId),
+      tx.pure.u64(args.amount),
+      tx.pure.u64(args.maxShares),
+      tx.pure.bool(args.fromDefault),
+      tx.object(ctx.sharedObjects.incentiveV2),
+      tx.object(args.market.incentiveV3Id),
+      tx.object(ctx.sharedObjects.suiSystemState)
+    ]
+  })
+}
+
+/**
+ * Appends `claim_reward` and returns the reward coin.
+ *
+ * One call settles every rule paying `rewardCoinType`. It has no freshness precondition
+ * and may stand alone, in which case only rewards already harvested into the vault are
+ * payable; harvesting first in the same block picks up the latest.
+ *
+ * Returns a zero-valued coin rather than aborting when nothing is claimable — the object
+ * still has to be consumed. Prefer omitting the call when the claimable amount is zero,
+ * so the recipient does not accumulate empty coin objects.
+ */
+export function claimRewardPTB(
+  tx: Transaction,
+  ctx: VaultTxContext,
+  args: {
+    receipt: TransactionObjectArgument
+    rewardCoinType: string
+  }
+): TransactionObjectArgument {
+  return tx.moveCall({
+    target: target(ctx.packageId, 'claim_reward'),
+    typeArguments: [ctx.descriptor.coinType, args.rewardCoinType],
+    arguments: [tx.object(ctx.descriptor.vault), args.receipt, tx.object(ctx.sharedObjects.clock)]
+  })
+}
+
+/** Appends `create_receipt` and returns the new receipt. */
+export function createReceiptPTB(tx: Transaction, ctx: VaultTxContext): TransactionObjectArgument {
+  return tx.moveCall({
+    target: target(ctx.packageId, 'create_receipt'),
+    typeArguments: [ctx.descriptor.coinType],
+    arguments: [tx.object(ctx.descriptor.vault)]
+  })
+}
+
+/** Appends `get_total_assets`, whose value is only meaningful after a sync prologue. */
+export function getTotalAssetsPTB(tx: Transaction, ctx: VaultTxContext): Transaction {
+  tx.moveCall({
+    target: target(ctx.packageId, 'get_total_assets'),
+    typeArguments: [ctx.descriptor.coinType],
+    arguments: [tx.object(ctx.descriptor.vault)]
+  })
+  return tx
+}
+
+/** Appends `get_user_shares` for a receipt. Needs no sync prologue. */
+export function getUserSharesPTB(
+  tx: Transaction,
+  ctx: VaultTxContext,
+  receiptId: string
+): Transaction {
+  tx.moveCall({
+    target: target(ctx.packageId, 'get_user_shares'),
+    typeArguments: [ctx.descriptor.coinType],
+    arguments: [tx.object(ctx.descriptor.vault), tx.object(receiptId)]
+  })
+  return tx
+}
+
+/** Appends `get_user_balance` for a receipt. Only meaningful after a sync prologue. */
+export function getUserBalancePTB(
+  tx: Transaction,
+  ctx: VaultTxContext,
+  receiptId: string
+): Transaction {
+  tx.moveCall({
+    target: target(ctx.packageId, 'get_user_balance'),
+    typeArguments: [ctx.descriptor.coinType],
+    arguments: [tx.object(ctx.descriptor.vault), tx.object(receiptId)]
+  })
+  return tx
+}
+
+/**
+ * Appends `get_user_claimable_reward_amount`.
+ *
+ * The value is a double-stale snapshot: the rule index only advances on harvest, and the
+ * holder's accrued total only advances when that holder interacts with the vault. An
+ * accurate figure requires simulating the settlement path instead — see `previewClaimReward`.
+ */
+export function getClaimableRewardPTB(
+  tx: Transaction,
+  ctx: VaultTxContext,
+  args: { receiptId: string; rewardCoinType: string }
+): Transaction {
+  tx.moveCall({
+    target: target(ctx.packageId, 'get_user_claimable_reward_amount'),
+    typeArguments: [ctx.descriptor.coinType, args.rewardCoinType],
+    arguments: [tx.object(ctx.descriptor.vault), tx.object(args.receiptId)]
+  })
+  return tx
+}

--- a/packages/vault/src/quote.ts
+++ b/packages/vault/src/quote.ts
@@ -1,0 +1,226 @@
+/**
+ * Vault Pricing
+ *
+ * Every figure here is produced by simulating a block that synchronizes the vault's
+ * markets before reading. This is not an optimization: `MarketInfo.current_balance` is
+ * written only by `sync_market_balance`, which happens as a side effect of someone
+ * constructing a deposit, withdrawal or allocation. A vault with no recent activity is
+ * not synchronized at all, and mainnet vaults have carried snapshots more than a month
+ * old. Reading the vault object's fields directly would report that stale figure with no
+ * indication of its age.
+ *
+ * Simulation discards the mutable references, so nothing is written on chain and no
+ * signature, key or funded account is required.
+ *
+ * @module VaultQuote
+ */
+
+import { Transaction } from '@mysten/sui/transactions'
+import { getVaultConfig, resolveVault } from './config'
+import { getVaultLayout, selectHarvestableRules } from './layout'
+import { appendOracleProloguePTB } from './oracle'
+import {
+  appendFreshnessPTB,
+  appendSyncMarketsPTB,
+  createTxContext,
+  getTotalAssetsPTB,
+  getUserBalancePTB,
+  getUserSharesPTB,
+  withdrawPTB
+} from './ptb'
+import type {
+  VaultBuildOptions,
+  VaultIdentifier,
+  VaultLayout,
+  VaultPosition,
+  VaultQuote,
+  VaultReadOptions
+} from './types'
+import { decode, decodeOne, simulate, tryDecodeCoinBalance } from './utils'
+import { resolveMarket } from './market'
+
+/**
+ * Reads a vault's assets, shares and per-market balances against a freshly synchronized
+ * snapshot.
+ */
+export async function getVaultQuote(
+  identifier: VaultIdentifier,
+  options?: VaultReadOptions & { layout?: VaultLayout }
+): Promise<VaultQuote> {
+  const config = await getVaultConfig(options)
+  const descriptor = resolveVault(identifier, config)
+  const layout = options?.layout ?? (await getVaultLayout(descriptor, options))
+  const ctx = createTxContext(config, descriptor)
+
+  const tx = new Transaction()
+  appendSyncMarketsPTB(tx, ctx, layout)
+  getTotalAssetsPTB(tx, ctx)
+
+  const marketCommandBase = layout.markets.length + 1
+  for (const market of layout.markets) {
+    tx.moveCall({
+      target: `${ctx.packageId}::navi_vault::get_market_info`,
+      typeArguments: [descriptor.coinType],
+      arguments: [tx.object(descriptor.vault), tx.pure.address(market.poolId)]
+    })
+  }
+
+  const results = await simulate(tx, options)
+
+  const totalAssets = decodeOne(results, layout.markets.length, decode.u64, 'get_total_assets')
+  const marketBalances: Record<string, bigint> = {}
+  layout.markets.forEach((market, index) => {
+    marketBalances[market.poolId] = decodeOne(
+      results,
+      marketCommandBase + index,
+      decode.u64,
+      `get_market_info[${market.poolId}]`
+    )
+  })
+
+  const depositHeadroom =
+    layout.vaultCap === 0n
+      ? null
+      : layout.vaultCap > totalAssets
+        ? layout.vaultCap - totalAssets
+        : 0n
+
+  return {
+    totalAssets,
+    totalShares: layout.totalShares,
+    idleBalance: layout.idleBalance,
+    marketBalances,
+    depositHeadroom
+  }
+}
+
+/**
+ * Values a holder's receipts against a synchronized snapshot.
+ *
+ * Each receipt is an independent position; a holder with several against one vault gets
+ * one entry per receipt, never a merged total.
+ */
+export async function getVaultPositions(
+  receiptIds: string[],
+  identifier: VaultIdentifier,
+  options?: VaultReadOptions & { layout?: VaultLayout }
+): Promise<VaultPosition[]> {
+  if (receiptIds.length === 0) return []
+
+  const config = await getVaultConfig(options)
+  const descriptor = resolveVault(identifier, config)
+  const layout = options?.layout ?? (await getVaultLayout(descriptor, options))
+  const ctx = createTxContext(config, descriptor)
+
+  const tx = new Transaction()
+  appendSyncMarketsPTB(tx, ctx, layout)
+  for (const receiptId of receiptIds) {
+    getUserSharesPTB(tx, ctx, receiptId)
+    getUserBalancePTB(tx, ctx, receiptId)
+  }
+
+  const results = await simulate(tx, options)
+  const base = layout.markets.length
+
+  return receiptIds.map((receiptId, index) => ({
+    receiptId,
+    shares: decodeOne(results, base + index * 2, decode.u64, `get_user_shares[${receiptId}]`),
+    balance: decodeOne(results, base + index * 2 + 1, decode.u64, `get_user_balance[${receiptId}]`)
+  }))
+}
+
+/** Result of simulating a withdrawal. */
+export type WithdrawPreview = {
+  /** Shares the withdrawal would burn, as computed by the contract. */
+  sharesBurned: bigint
+  /** Assets the withdrawal would return, read from the produced coin when decodable. */
+  amountOut?: bigint
+  /**
+   * Suggested `maxShares` — {@link sharesBurned} plus {@link toleranceBps}.
+   *
+   * Drift between simulation and execution is favourable: interest accrual raises share
+   * price, so the same amount costs marginally fewer shares later. The tolerance covers
+   * rounding and any fee accrual in the interval.
+   */
+  maxShares: bigint
+  /** Tolerance applied, in basis points. */
+  toleranceBps: number
+}
+
+/**
+ * Simulates a withdrawal to derive `maxShares`.
+ *
+ * This is the only reliable way to size the slippage bound: `convert_to_shares` models
+ * none of the non-default-market penalty, ceiling rounding, idle-first routing, or
+ * same-transaction fee accrual that determine what is actually burned.
+ *
+ * @param amount - Amount in native decimals. Pass {@link MAX_U64} with `fromDefault` to
+ *   preview a full exit.
+ * @param toleranceBps - Headroom added to the simulated figure. Defaults to 30 bps.
+ */
+export async function previewWithdraw(
+  args: {
+    vault: VaultIdentifier
+    receiptId: string
+    amount: bigint
+    sender: string
+    fromDefault?: boolean
+    poolId?: string
+  },
+  options?: VaultBuildOptions & { toleranceBps?: number; updatePythPriceFeeds?: boolean }
+): Promise<WithdrawPreview> {
+  const config = await getVaultConfig(options)
+  const descriptor = resolveVault(args.vault, config)
+  const layout = options?.layout ?? (await getVaultLayout(descriptor, options))
+  const ctx = createTxContext(config, descriptor)
+  const fromDefault = args.fromDefault ?? true
+  const market = resolveMarket(layout, { fromDefault, poolId: args.poolId })
+
+  const tx = new Transaction()
+  await appendOracleProloguePTB(tx, descriptor, options)
+  appendFreshnessPTB(tx, ctx, layout, selectHarvestableRules(layout, descriptor))
+  withdrawPTB(tx, ctx, {
+    market,
+    receipt: tx.object(args.receiptId),
+    amount: args.amount,
+    // No bound during simulation: the point of the call is to learn what the bound
+    // should be, and a guessed one would abort before telling us.
+    maxShares: 0n,
+    fromDefault
+  })
+
+  const results = await simulate(tx, { ...options, sender: args.sender })
+
+  // The oracle prologue's command count varies with Pyth staleness, so index from the
+  // end rather than from a computed offset.
+  const withdrawResult = results[results.length - 1]
+  if (!withdrawResult) {
+    throw new Error('Withdrawal simulation returned no results')
+  }
+
+  // withdraw returns (Coin<CoinType>, u64); the shares figure is the second value.
+  const sharesBytes = withdrawResult[1]
+  if (!sharesBytes) {
+    throw new Error('Withdrawal simulation did not return a shares_burned value')
+  }
+  const sharesBurned = decode.u64(sharesBytes)
+
+  const toleranceBps = options?.toleranceBps ?? 30
+  return {
+    sharesBurned,
+    amountOut: tryDecodeCoinBalance(withdrawResult[0]),
+    maxShares: sharesBurned + (sharesBurned * BigInt(toleranceBps)) / 10_000n,
+    toleranceBps
+  }
+}
+
+/**
+ * Assets per share, as a float.
+ *
+ * Display only — lossy, and unusable for any on-chain amount. Returns 1 for an empty
+ * vault, matching the contract's virtual-share behaviour at zero supply.
+ */
+export function sharePrice(quote: Pick<VaultQuote, 'totalAssets' | 'totalShares'>): number {
+  if (quote.totalShares === 0n) return 1
+  return Number(quote.totalAssets) / Number(quote.totalShares)
+}

--- a/packages/vault/src/reward.ts
+++ b/packages/vault/src/reward.ts
@@ -1,0 +1,141 @@
+/**
+ * Vault Rewards
+ *
+ * Rewards reach a holder in two hops. `collect_reward` harvests from NAVI's incentive
+ * into the vault's reward bag and advances the rule's index; `claim_reward` pays a
+ * holder out of that bag according to their share of the index growth. Vault-native
+ * rules skip the first hop — they are settled from a per-millisecond rate inside the
+ * vault.
+ *
+ * @module VaultReward
+ */
+
+import { Transaction } from '@mysten/sui/transactions'
+import { normalizeCoinType } from '@naviprotocol/lending'
+import { getVaultConfig, resolveVault } from './config'
+import { getVaultLayout, selectHarvestableRules } from './layout'
+import {
+  appendCollectRewardsPTB,
+  claimRewardPTB,
+  createTxContext,
+  getClaimableRewardPTB
+} from './ptb'
+import type {
+  ClaimRewardArgs,
+  VaultBuildOptions,
+  VaultIdentifier,
+  VaultLayout,
+  VaultReadOptions
+} from './types'
+import { decode, decodeOne, simulate, tryDecodeCoinBalance } from './utils'
+
+/** Distinct reward coin types a vault currently pays. */
+export async function getRewardCoinTypes(
+  identifier: VaultIdentifier,
+  options?: VaultReadOptions & { layout?: VaultLayout }
+): Promise<string[]> {
+  const config = await getVaultConfig(options)
+  const descriptor = resolveVault(identifier, config)
+  const layout = options?.layout ?? (await getVaultLayout(descriptor, options))
+  return [...new Set(layout.rules.filter((rule) => rule.isActive).map((r) => r.rewardCoinType))]
+}
+
+/**
+ * Reads the contract's recorded claimable amount.
+ *
+ * Fast but understated, in two independent ways: a rule's index only advances when it is
+ * harvested, and a holder's accrued total only advances when that holder interacts with
+ * the vault. A holder who has not deposited, withdrawn or claimed since the last index
+ * growth reads low. Use {@link previewClaimReward} when the figure has to be right.
+ */
+export async function getRecordedClaimableReward(
+  args: { vault: VaultIdentifier; receiptId: string; rewardCoinType: string },
+  options?: VaultReadOptions
+): Promise<bigint> {
+  const config = await getVaultConfig(options)
+  const descriptor = resolveVault(args.vault, config)
+  const ctx = createTxContext(config, descriptor)
+
+  const tx = new Transaction()
+  getClaimableRewardPTB(tx, ctx, {
+    receiptId: args.receiptId,
+    rewardCoinType: args.rewardCoinType
+  })
+
+  const results = await simulate(tx, options)
+  return decodeOne(results, 0, decode.u64, 'get_user_claimable_reward_amount')
+}
+
+/**
+ * Simulates harvest-then-claim and reports what the holder would actually receive.
+ *
+ * This resolves both lags in the recorded figure: harvesting advances the rule indices,
+ * and `claim_reward` settles the holder's accrued total as part of the same block. No
+ * view function can report this, because resolving the second lag requires mutating the
+ * holder's state.
+ */
+export async function previewClaimReward(
+  args: ClaimRewardArgs,
+  options?: VaultBuildOptions
+): Promise<bigint> {
+  const config = await getVaultConfig(options)
+  const descriptor = resolveVault(args.vault, config)
+  const layout = options?.layout ?? (await getVaultLayout(descriptor, options))
+  const ctx = createTxContext(config, descriptor)
+  const rewardCoinType = normalizeCoinType(args.rewardCoinType)
+
+  const harvestable = selectHarvestableRules(layout, descriptor).filter(
+    (rule) => normalizeCoinType(rule.rewardCoinType) === rewardCoinType
+  )
+
+  const tx = new Transaction()
+  appendCollectRewardsPTB(tx, ctx, harvestable)
+  claimRewardPTB(tx, ctx, {
+    receipt: tx.object(args.receiptId),
+    rewardCoinType: args.rewardCoinType
+  })
+
+  const results = await simulate(tx, { ...options, sender: args.sender })
+  const claim = results[results.length - 1]
+  return tryDecodeCoinBalance(claim?.[0]) ?? 0n
+}
+
+/**
+ * Builds a reward claim.
+ *
+ * Harvests the rules paying this coin first so the claim picks up the latest protocol
+ * rewards, then claims. One call settles every rule paying `rewardCoinType`.
+ *
+ * `claim_reward` returns a zero-valued coin rather than aborting when nothing is
+ * claimable, and that object still has to be consumed — which is why it is worth
+ * checking {@link previewClaimReward} first rather than routinely building claims that
+ * deposit empty coin objects in the holder's account.
+ */
+export async function buildClaimRewardTx(
+  args: ClaimRewardArgs,
+  options?: VaultBuildOptions & { harvestFirst?: boolean }
+): Promise<Transaction> {
+  const config = await getVaultConfig(options)
+  const descriptor = resolveVault(args.vault, config)
+  const layout = options?.layout ?? (await getVaultLayout(descriptor, options))
+  const ctx = createTxContext(config, descriptor)
+  const rewardCoinType = normalizeCoinType(args.rewardCoinType)
+
+  const tx = new Transaction()
+  tx.setSenderIfNotSet(args.sender)
+
+  if (options?.harvestFirst ?? true) {
+    const harvestable = selectHarvestableRules(layout, descriptor).filter(
+      (rule) => normalizeCoinType(rule.rewardCoinType) === rewardCoinType
+    )
+    appendCollectRewardsPTB(tx, ctx, harvestable)
+  }
+
+  const coin = claimRewardPTB(tx, ctx, {
+    receipt: tx.object(args.receiptId),
+    rewardCoinType: args.rewardCoinType
+  })
+  tx.transferObjects([coin], tx.pure.address(args.sender))
+
+  return tx
+}

--- a/packages/vault/src/snapshot.ts
+++ b/packages/vault/src/snapshot.ts
@@ -1,0 +1,235 @@
+/**
+ * Bundled Mainnet Configuration Snapshot
+ *
+ * Generated from chain on 2026-08-05 by `navi_vault_setup/dump_vaults.ts`. This is a
+ * fallback so the SDK works without a configuration service; it is not authoritative.
+ *
+ * Only identifiers live here. Anything an admin or curator can change without a
+ * redeploy — pause state, caps, fees, penalties, market membership, rule activity — is
+ * deliberately absent and must be read from chain via `getVaultLayout`.
+ *
+ * `packageId` changes on every contract upgrade, so a stale snapshot silently runs
+ * superseded code. Override it with {@link configureVaultSdk} rather than relying on an
+ * SDK release to carry the new value.
+ *
+ * @module VaultSnapshot
+ */
+
+import type { VaultConfig } from './types'
+
+/** Date the snapshot was dumped from chain, ISO 8601. */
+export const SNAPSHOT_GENERATED_AT = '2026-08-05T06:45:58.096Z'
+
+/** Mainnet configuration as of {@link SNAPSHOT_GENERATED_AT}. */
+export const MAINNET_VAULT_CONFIG: VaultConfig = {
+  package: {
+    packageId: '0x13e1e0ddcf3a76cde006d530e98a0f985c446013cfedeae6dd067a2f1ea88ff5',
+    typePackageId: '0x51cecaacaed0bd436f04ebbd8ba0ca1627c9c4d0e54ad28eff095ca78591518c',
+    expectedVaultVersion: 2
+  },
+  sharedObjects: {
+    clock: '0x6',
+    priceOracle: '0x1568865ed9a0b5ec414220e8f79b3d04c77acc82358f6e5ae4635687392ffbef',
+    incentiveV2: '0xf87a8acb8b81d14307894d12595541a73f19933f88e1326d5be349c7a6f7559c',
+    suiSystemState: '0x5'
+  },
+  vaults: [
+    {
+      key: 'SUI',
+      displayName: 'SUI High Yield',
+      vault: '0x864527a8ed2435aed828b46c6d9d0244506b418761cca25b7dd47a83c7797a29',
+      timelocks: '0x04523a8d1f1a3019f9b8f5e61984544d5dfc467ec0e91d64f228a17e30737264',
+      coinType: '0x2::sui::SUI',
+      decimals: 9,
+      markets: [
+        {
+          name: 'main',
+          pool: '0x96df0fce3c471489f4debaaa762cf960b3d97820bd1f3f025ff8190730e958c5',
+          storage: '0xbb4e2f4b6205c2e2a2db47aeb4f830796ec7c005f88537ee775986639bc442fe',
+          incentiveV3: '0x62982dad27fb10bb314b3384d5de8d2ac2d72ab2dbeae5d801dbdb9efa816c80',
+          assetId: 0,
+          isDefault: true
+        },
+        {
+          name: 'suieco',
+          pool: '0xc1dfd32ec30a1ba16e8c1d32a284718ac8f41765722f27fe7fb9d0b38a570ae0',
+          storage: '0xdf18372bc9c588b96c7553bc811467a9166ed9be472b40cb45c226175377c558',
+          incentiveV3: '0x5ddc7f50eff9396f3f401a6194dda7b64c2ffc64fd581d119c44ae0587119309',
+          assetId: 0,
+          isDefault: false
+        },
+        {
+          name: 'vsui-sui',
+          pool: '0x3f2d878005dd9d5caf56467bc0c55f93bb5a3c83a5c7fb057032a0abf1bad4bf',
+          storage: '0xafb982de1a436b1cc8a14ecd2d787762599b65d3a6b75b84b10939b1e17d9381',
+          incentiveV3: '0x5a1d3333b37d206033bb49859d306e546cc8d9b81a0c854d899752227a91a2de',
+          assetId: 1,
+          isDefault: false
+        }
+      ],
+      rewardRules: [
+        {
+          index: 0,
+          naviPoolId: '0x96df0fce3c471489f4debaaa762cf960b3d97820bd1f3f025ff8190730e958c5',
+          incentiveRuleId: '0xd483f186fa678d5f93912f5960f97f29796c12902245b79b9b7a87a4ca407e5a',
+          rewardCoinType:
+            '0x549e8b69270defbfafd4f94e17ec44cdbdd99820b33bda2278dea3b9a32d3f55::cert::CERT',
+          isVaultNative: false,
+          isActive: true,
+          mustCollectBeforeWithdraw: true,
+          rewardFund: '0x7093cf7549d5e5b35bfde2177223d1050f71655c7f676a5e610ee70eb4d93b5c',
+          storage: '0xbb4e2f4b6205c2e2a2db47aeb4f830796ec7c005f88537ee775986639bc442fe',
+          incentiveV3: '0x62982dad27fb10bb314b3384d5de8d2ac2d72ab2dbeae5d801dbdb9efa816c80'
+        }
+      ]
+    },
+    {
+      key: 'USDC',
+      displayName: 'USDC High Yield',
+      vault: '0x54359eb5d0e4364bd26989899fdb472f5594d1885e1f0d816ef4a066cab2ae4c',
+      timelocks: '0x80696a1a627f9e02059c9dfed0e94ef7905424bc602ff85d3ad9fc47638887a6',
+      coinType: '0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC',
+      decimals: 6,
+      markets: [
+        {
+          name: 'main',
+          pool: '0xa3582097b4c57630046c0c49a88bfc6b202a3ec0a9db5597c31765f7563755a8',
+          storage: '0xbb4e2f4b6205c2e2a2db47aeb4f830796ec7c005f88537ee775986639bc442fe',
+          incentiveV3: '0x62982dad27fb10bb314b3384d5de8d2ac2d72ab2dbeae5d801dbdb9efa816c80',
+          assetId: 10,
+          isDefault: true
+        },
+        {
+          name: 'suieco',
+          pool: '0x085b81d73c936f453a407b0ca5aaebe5a4feafe198e150dba316ce3881444967',
+          storage: '0xdf18372bc9c588b96c7553bc811467a9166ed9be472b40cb45c226175377c558',
+          incentiveV3: '0x5ddc7f50eff9396f3f401a6194dda7b64c2ffc64fd581d119c44ae0587119309',
+          assetId: 1,
+          isDefault: false
+        },
+        {
+          name: 'ember',
+          pool: '0x660194c215d84cf9ac1de39de440edc059671ce04ee8131374159472a791ff84',
+          storage: '0xc2b6a52f0da7f91389eaffe4f68f4cacee43aa616bb8a4371118eafaf07cdd90',
+          incentiveV3: '0x715f4d383c3fbc999c9a8030d540bf2348d65cac1cb6aa8e9fab31cd408bff55',
+          assetId: 0,
+          isDefault: false
+        },
+        {
+          name: 'matrixdock',
+          pool: '0xb2236866d2aacdd2368ffbb4c8afd6832e6a612aa7632fe13bdcdcd47db84208',
+          storage: '0x199c1d5c2d58a4b05bbfa2338d02ad2676572a8a59ac148a5475b5c0fc53ed9f',
+          incentiveV3: '0x98612a501041cb7b57edeae28b2029f55a294aae5736ab2dda629523125d7197',
+          assetId: 0,
+          isDefault: false
+        },
+        {
+          name: 'sui-usdc',
+          pool: '0x981de52ee841ac80387e0edd85c944197a273110043351e1bf5242b47c23abe8',
+          storage: '0x51c5ad179214eb5e170dd93ba6f9b15948002caf85f7e2b091ef46d2dc2ce5b6',
+          incentiveV3: '0x78b4a72683b9a36ea30877a27fd0040adbc0539fc11c2f2507fb560a83b82815',
+          assetId: 1,
+          isDefault: false
+        }
+      ],
+      rewardRules: [
+        {
+          index: 0,
+          naviPoolId: '0xa3582097b4c57630046c0c49a88bfc6b202a3ec0a9db5597c31765f7563755a8',
+          incentiveRuleId: '0xae82946d6cae4d5e7a779325394959fd7c2505405de71b2c01a2aac6ec3ab9da',
+          rewardCoinType:
+            '0x549e8b69270defbfafd4f94e17ec44cdbdd99820b33bda2278dea3b9a32d3f55::cert::CERT',
+          isVaultNative: false,
+          isActive: true,
+          mustCollectBeforeWithdraw: true,
+          rewardFund: '0x7093cf7549d5e5b35bfde2177223d1050f71655c7f676a5e610ee70eb4d93b5c',
+          storage: '0xbb4e2f4b6205c2e2a2db47aeb4f830796ec7c005f88537ee775986639bc442fe',
+          incentiveV3: '0x62982dad27fb10bb314b3384d5de8d2ac2d72ab2dbeae5d801dbdb9efa816c80'
+        },
+        {
+          index: 1,
+          naviPoolId: '0x0000000000000000000000000000000000000000000000000000000000000000',
+          incentiveRuleId: '0x0000000000000000000000000000000000000000000000000000000000000000',
+          rewardCoinType:
+            '0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI',
+          isVaultNative: true,
+          isActive: false,
+          mustCollectBeforeWithdraw: false,
+          rewardFund: null,
+          storage: null,
+          incentiveV3: null
+        }
+      ]
+    },
+    {
+      key: 'SUI_PRIME',
+      displayName: 'SUI Prime',
+      vault: '0x01236ff6c66c0c668950f9702629b42f372bf478793d055d2a7eca15e0b0d1e7',
+      timelocks: '0x3f1533e62792cb686b3dd794d408a83a653a1f3b553224c70c7dfcc8b290dcf4',
+      coinType: '0x2::sui::SUI',
+      decimals: 9,
+      markets: [
+        {
+          name: 'vsui-sui',
+          pool: '0x3f2d878005dd9d5caf56467bc0c55f93bb5a3c83a5c7fb057032a0abf1bad4bf',
+          storage: '0xafb982de1a436b1cc8a14ecd2d787762599b65d3a6b75b84b10939b1e17d9381',
+          incentiveV3: '0x5a1d3333b37d206033bb49859d306e546cc8d9b81a0c854d899752227a91a2de',
+          assetId: 1,
+          isDefault: true
+        },
+        {
+          name: 'hasui-sui',
+          pool: '0xe75ea5ed5f37d8c86b1f2742dd408d380ab5845bb1aabeba8fbee38dd5824765',
+          storage: '0x6b945adccadf11cd7ec39f8c2c225a4267004a74587871cac86f9fa3dbf3be63',
+          incentiveV3: '0x036e2854c386099d3bb44533160079e13a2e081952065b37467f859c6b73eb64',
+          assetId: 1,
+          isDefault: false
+        }
+      ],
+      rewardRules: []
+    },
+    {
+      key: 'USDC_PRIME',
+      displayName: 'USDC Prime',
+      vault: '0x908c978d1a007aec4bcdc8233a0273de27ab059b9e6611bdad083457abb7f062',
+      timelocks: '0x0aaebd50fbc34041706d2e153fbfe31b475f38e6055bb788340aa9eecba45364',
+      coinType: '0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC',
+      decimals: 6,
+      markets: [
+        {
+          name: 'sui-usdc',
+          pool: '0x981de52ee841ac80387e0edd85c944197a273110043351e1bf5242b47c23abe8',
+          storage: '0x51c5ad179214eb5e170dd93ba6f9b15948002caf85f7e2b091ef46d2dc2ce5b6',
+          incentiveV3: '0x78b4a72683b9a36ea30877a27fd0040adbc0539fc11c2f2507fb560a83b82815',
+          assetId: 1,
+          isDefault: true
+        },
+        {
+          name: 'lzwbtc-usdc',
+          pool: '0x04b66a9a2619d2c22b4845133945ab3e7e613a470af1c66861587a6e72fc3c32',
+          storage: '0x79db6cdbfb59a067be7d78c1003079f56d817ac33b5d372b3165daf09f31ed69',
+          incentiveV3: '0xf0263a942969226ec12fd81f1bac355d08150b4c0c730bd88a598ce8e8de1df9',
+          assetId: 1,
+          isDefault: false
+        },
+        {
+          name: 'vsui-usdc',
+          pool: '0xa5416a944ea690a26ef6cf1e3745dabd73f84d4143a741b2a2bb0e217f4f8d65',
+          storage: '0x35fecf669e7794ad25d289c2a23f065e518351acae09c5032d7237e185257924',
+          incentiveV3: '0xa7955f8aea32d8624b0c26c64c714a5c7abd3f5ef5a6a8b04bb35d5442f7c46b',
+          assetId: 1,
+          isDefault: false
+        },
+        {
+          name: 'xbtc-usdc',
+          pool: '0x8ef9ddbe70a3e796a5c191bb0418a2f1a03f5f6d10244bcc0c666826e066eb4b',
+          storage: '0x7db5c000524bfe55bb2bc343886f29eabc38f706dc1655900055fa5b60ee00a5',
+          incentiveV3: '0xfc707b0a65ccf21cba1a7c8e0fa4dbabfdda605a8f3b957c8dcf19aa3921315f',
+          assetId: 1,
+          isDefault: false
+        }
+      ],
+      rewardRules: []
+    }
+  ]
+}

--- a/packages/vault/src/types.ts
+++ b/packages/vault/src/types.ts
@@ -1,0 +1,374 @@
+/**
+ * Vault Type Definitions
+ *
+ * Types for the NAVI Vault protocol: static configuration (package ids, vault and
+ * market object ids) and live on-chain layout (market balances, reward rules, fees).
+ *
+ * ## Units
+ *
+ * Raw on-chain integers are `bigint` throughout. Their scales differ per field and are
+ * NOT interchangeable:
+ *
+ * | Quantity                                            | Scale                        |
+ * | --------------------------------------------------- | ---------------------------- |
+ * | amounts (`deposit`, `withdraw`, `currentBalance`, …) | token native decimals        |
+ * | `MarketLayout.loss`                                  | always 9 decimals            |
+ * | `managementFee`, `performanceFee`, `penalty`         | WAD (1e18 = 100%)            |
+ * | `vaultRewardIndex`, `rewardRate`                     | RAY (1e27), rate is per ms   |
+ * | `lastSyncAtMs`, `lastHarvestAtMs`                    | milliseconds                 |
+ * | `lastUpdateTimestamp`, timelock timestamps           | seconds                      |
+ *
+ * @module VaultTypes
+ */
+
+import type { Transaction } from '@mysten/sui/transactions'
+import type { CacheOption, EnvOption, ServiceOption, SuiClientOption } from '@naviprotocol/lending'
+
+/**
+ * Package identifiers for the navi_vault contract.
+ *
+ * `packageId` and `typePackageId` are NOT interchangeable and using one where the other
+ * belongs fails silently in both directions — see the field docs.
+ */
+export type VaultPackageConfig = {
+  /**
+   * LATEST published navi_vault package. The `target` of every moveCall.
+   *
+   * Changes on every contract upgrade. Calling a superseded package runs superseded code
+   * until the vault's dependencies move underneath it, then aborts 1400.
+   */
+  packageId: string
+  /**
+   * ORIGINAL navi_vault package. Used for every type string — owned-object filters,
+   * event filters, `objectType` matching. Fixed for the lifetime of the deployment.
+   *
+   * A Sui upgrade never changes type identity. Using `packageId` here matches zero
+   * objects and reports no error.
+   */
+  typePackageId: string
+  /**
+   * Contract version {@link packageId} expects vault objects to carry.
+   *
+   * The contract gates every entrypoint on `vault.version == this_version()`, so a vault
+   * that has not been migrated after a package upgrade aborts `E_INCORRECT_VERSION`
+   * (10036) on every call. Checking it before building turns a paid, failed transaction
+   * into a build-time error.
+   *
+   * Omit to skip the check — appropriate only when the configuration cannot be kept in
+   * step with the deployed package.
+   */
+  expectedVaultVersion?: number
+}
+
+/** Shared objects required by vault transactions but not discoverable from vault state. */
+export type VaultSharedObjects = {
+  /** Always `0x6`. */
+  clock: string
+  /** NAVI PriceOracle. Required by `withdraw` and `deallocate` only. */
+  priceOracle: string
+  /** NAVI incentive_v2. Global, shared by every market. */
+  incentiveV2: string
+  /** Always `0x5`. */
+  suiSystemState: string
+}
+
+/**
+ * A NAVI lending market registered on a vault, as configured.
+ *
+ * The live counterpart is {@link MarketLayout}, which additionally carries the balance
+ * snapshot and status. Never build a transaction from this type alone — market
+ * membership can change on chain (see {@link VaultLayout}).
+ */
+export type VaultMarketConfig = {
+  /** Human-readable market name, e.g. `main`, `vsui-sui`. Cosmetic only. */
+  name: string
+  /** `Pool<CoinType>` object id. Identifies the market. */
+  pool: string
+  /** `Storage` object id of the NAVI lending instance this market belongs to. */
+  storage: string
+  /** `incentive_v3` object id for this market. */
+  incentiveV3: string
+  /** Reserve index within `storage`. Distinct markets may reuse the same index. */
+  assetId: number
+  /**
+   * Whether this is the vault's deposit routing target. Not always the market named
+   * `main` — read {@link VaultLayout.defaultMarket} at runtime rather than trusting this.
+   */
+  isDefault: boolean
+}
+
+/** A reward rule registered on a vault, as configured. */
+export type VaultRewardRuleConfig = {
+  /** Stable index into the contract's append-only `reward_rules` vector. */
+  index: number
+  /** Pool address the rule is attached to. Zero address for vault-native rules. */
+  naviPoolId: string
+  /** `incentive_v3` rule id. Zero address for vault-native rules. */
+  incentiveRuleId: string
+  /** Fully qualified reward coin type. */
+  rewardCoinType: string
+  /** Vault-native rules are settled internally and are never harvested from a market. */
+  isVaultNative: boolean
+  /** Inactive rules are skipped by `collect_reward` but retain claimable history. */
+  isActive: boolean
+  /** True when this rule must be harvested in the same block as deposit/withdraw. */
+  mustCollectBeforeWithdraw: boolean
+  /** `RewardFund<RewardCoinType>` object id. Null for vault-native or inactive rules. */
+  rewardFund: string | null
+  /** `Storage` of the market this rule harvests from. Null for vault-native rules. */
+  storage: string | null
+  /** `incentive_v3` of the market this rule harvests from. Null for vault-native rules. */
+  incentiveV3: string | null
+}
+
+/**
+ * A single vault, as configured.
+ *
+ * Fields that an admin or curator can change without a redeploy — pause state, caps,
+ * fees, penalties, market membership — are deliberately absent. Read them at runtime
+ * via {@link VaultLayout}.
+ */
+export type VaultDescriptor = {
+  /** Stable key, e.g. `SUI`, `USDC_PRIME`. */
+  key: string
+  /** Display name, e.g. `SUI High Yield`. */
+  displayName: string
+  /** Shared `Vault<CoinType>` object id. The only thing that identifies a vault. */
+  vault: string
+  /** Shared `Timelocks<CoinType>` object id. Only needed to read governance proposals. */
+  timelocks: string
+  /** Fully qualified underlying coin type. */
+  coinType: string
+  /** Native decimals of {@link coinType}. */
+  decimals: number
+  /** Markets registered at configuration time. Verify against chain before building. */
+  markets: VaultMarketConfig[]
+  /** Reward rules registered at configuration time. Verify against chain before building. */
+  rewardRules: VaultRewardRuleConfig[]
+}
+
+/** Complete vault configuration. */
+export type VaultConfig = {
+  package: VaultPackageConfig
+  sharedObjects: VaultSharedObjects
+  vaults: VaultDescriptor[]
+}
+
+/** Market status discriminant as stored on chain. */
+export enum MarketStatus {
+  /** Accepts deposits, allocations and withdrawals. */
+  Active = 0,
+  /**
+   * No new inflows, but still counted in AUM and still withdrawable — and therefore
+   * still required to be synchronized before deposit/withdraw.
+   */
+  Disabled = 1
+}
+
+/** Live market state read from the vault object. */
+export type MarketLayout = {
+  /** `Pool<CoinType>` object id. */
+  poolId: string
+  /** Deposit cap in native decimals. `0n` means unlimited. */
+  cap: bigint
+  /** Withdrawal penalty, WAD-scaled. Applies only to non-default markets, capped at 30%. */
+  penalty: bigint
+  /** Admin-assigned bad debt. Always 9 decimals, regardless of the token's decimals. */
+  loss: bigint
+  status: MarketStatus
+  /** Milliseconds. `0n` means never synchronized. */
+  lastSyncAtMs: bigint
+  storageId: string
+  assetId: number
+  incentiveV3Id: string
+  incentiveV2Id: string
+  /** Cached position in native decimals, as of {@link lastSyncAtMs}. Stale between syncs. */
+  currentBalance: bigint
+}
+
+/** Live reward rule state read from the vault object. */
+export type RewardRuleLayout = {
+  /** Index into the contract's append-only rule vector. Stable for the vault's lifetime. */
+  index: number
+  naviPoolId: string
+  rewardCoinType: string
+  incentiveRuleId: string
+  /** RAY-scaled (1e27). */
+  vaultRewardIndex: bigint
+  /** Milliseconds. */
+  lastHarvestAtMs: bigint
+  isVaultNative: boolean
+  /** RAY-scaled per millisecond. `0n` for market rules. */
+  rewardRate: bigint
+  isActive: boolean
+  /** Vault-native budget cap. `0n` for market rules. */
+  totalRewardDeposited: bigint
+  /** Vault-native amount already distributed via index growth. `0n` for market rules. */
+  totalRewardDistributed: bigint
+}
+
+/**
+ * Live vault state.
+ *
+ * Must be read at transaction-construction time and must NOT be cached across
+ * transactions: `add_market` initializes a market with `lastSyncAtMs = 0n`, and
+ * `set_loss` resets an existing market's, either of which makes a transaction built
+ * from a stale layout abort with `E_MARKET_NOT_READ`.
+ */
+export type VaultLayout = {
+  /** Every registered market, Active and Disabled alike. All require synchronization. */
+  markets: MarketLayout[]
+  rules: RewardRuleLayout[]
+  /** Deposit routing target. Zero address means deposits accumulate in the idle balance. */
+  defaultMarket: string
+  paused: boolean
+  /** Contract version of the vault object. Must match the deployed package. */
+  version: bigint
+  /** Vault-level deposit cap in native decimals. `0n` means unlimited. */
+  vaultCap: bigint
+  /** WAD-scaled annual rate, capped at 20%. */
+  managementFee: bigint
+  /** WAD-scaled share of profit, capped at 40%. */
+  performanceFee: bigint
+  /** Assets held in the vault but not deployed to any market, in native decimals. */
+  idleBalance: bigint
+  /** Total shares outstanding, including accrued but unclaimed fee shares. */
+  totalShares: bigint
+}
+
+/** Rules that must be harvested in the same block as a deposit or withdrawal. */
+export type HarvestableRule = RewardRuleLayout & {
+  /** Resolved `RewardFund<RewardCoinType>` object id. */
+  rewardFund: string
+  /** `Storage` of the market this rule harvests from. */
+  storageId: string
+  /** `incentive_v3` of the market this rule harvests from. */
+  incentiveV3Id: string
+}
+
+/** A depositor's position object. */
+export type VaultReceipt = {
+  /** Receipt object id. */
+  objectId: string
+  /**
+   * The vault this receipt belongs to. `Receipt` is not generic — one type covers every
+   * vault — so this field is the only way to attribute a receipt.
+   */
+  vaultAddress: string
+}
+
+/** Synchronized snapshot of a vault's pricing state. */
+export type VaultQuote = {
+  /** Assets under management in native decimals, as of a freshly synchronized read. */
+  totalAssets: bigint
+  totalShares: bigint
+  idleBalance: bigint
+  /** Per-market synchronized balances, keyed by pool id. */
+  marketBalances: Record<string, bigint>
+  /**
+   * Remaining vault-level deposit headroom in native decimals, or `null` when uncapped.
+   *
+   * This is the vault's own bound only. The effective headroom is the minimum of this,
+   * the target market's cap, and NAVI's reserve supply ceiling — the last of which is
+   * shared with every other participant in that reserve and cannot be derived from
+   * vault state.
+   */
+  depositHeadroom: bigint | null
+}
+
+/** A holder's position, valued against a synchronized snapshot. */
+export type VaultPosition = {
+  receiptId: string
+  shares: bigint
+  /** Value in native decimals. */
+  balance: bigint
+}
+
+/** Identifies a vault: its object id, its config key, or a full descriptor. */
+export type VaultIdentifier = string | VaultDescriptor
+
+/** Selects which vault an operation targets. */
+export type VaultOption = {
+  vault: VaultIdentifier
+}
+
+/**
+ * Supplies a pre-read layout, skipping the round trip that reads it.
+ *
+ * Only pass a layout obtained during the construction of the current transaction.
+ */
+export type LayoutOption = {
+  layout: VaultLayout
+}
+
+/** Overrides the bundled configuration snapshot. */
+export type VaultConfigOption = {
+  config: VaultConfig
+}
+
+/** Options accepted by read paths. */
+export type VaultReadOptions = Partial<
+  EnvOption & CacheOption & SuiClientOption & ServiceOption & VaultConfigOption
+>
+
+/** Options accepted by transaction builders. */
+export type VaultBuildOptions = Partial<
+  EnvOption & SuiClientOption & ServiceOption & VaultConfigOption & LayoutOption
+>
+
+/** Arguments for building a deposit. */
+export type DepositArgs = {
+  vault: VaultIdentifier
+  /** Amount in native decimals. The deposit coin is split to exactly this value. */
+  amount: bigint
+  /** Depositor address. Receives the receipt. */
+  sender: string
+  /**
+   * Which position to credit.
+   *
+   * - omitted — resolve automatically: reuse the sender's receipt when they hold exactly
+   *   one, mint a new one when they hold none. Holding several is ambiguous and raises an
+   *   error listing them, because a receipt *is* a position and guessing which to top up
+   *   is what leaves stray empty ones behind. Costs one extra read (~60ms).
+   * - a receipt object id — credit that position. No lookup.
+   * - `'new'` — open a fresh position. No lookup. A holder may hold any number of
+   *   receipts against one vault; they are independent and never merge.
+   */
+  position?: string | 'new'
+  /**
+   * Coin to draw the deposit from. Defaults to `tx.gas` for SUI vaults, which is only
+   * correct when the underlying asset is SUI.
+   */
+  coin?: Parameters<Transaction['splitCoins']>[0]
+}
+
+/** Arguments for building a withdrawal. */
+export type WithdrawArgs = {
+  vault: VaultIdentifier
+  receiptId: string
+  /** Amount in native decimals. Clamped to the holder's maximum when `fromDefault`. */
+  amount: bigint
+  sender: string
+  /**
+   * Upper bound on shares burned. `0n` disables the check entirely — it means
+   * "no limit", not "no shares". Derive it from a simulated withdrawal.
+   */
+  maxShares: bigint
+  /**
+   * When true, `pool` must be the default market and no penalty applies. When false,
+   * any registered market may be drawn from and that market's penalty applies to the
+   * portion actually taken from it.
+   */
+  fromDefault?: boolean
+  /** Market to draw the shortfall from. Defaults to the vault's default market. */
+  poolId?: string
+}
+
+/** Arguments for building a reward claim. */
+export type ClaimRewardArgs = {
+  vault: VaultIdentifier
+  receiptId: string
+  /** Reward coin type to claim. One call settles every rule paying this coin. */
+  rewardCoinType: string
+  sender: string
+}

--- a/packages/vault/src/utils.ts
+++ b/packages/vault/src/utils.ts
@@ -1,0 +1,247 @@
+/**
+ * Vault Utilities
+ *
+ * Read-only simulation and BCS decoding of Move return values.
+ *
+ * Vault view functions cannot be read from the object's fields: a market position is a
+ * cached figure refreshed only by an explicit `sync_market_balance`, and vaults with no
+ * recent activity have carried snapshots more than a month old. Every pricing read
+ * therefore goes through a simulated block that synchronizes first, which is what these
+ * helpers exist to support.
+ *
+ * ## Why decoding is schema-driven
+ *
+ * Sui's JSON-RPC `devInspectTransactionBlock` tags each return value with its Move type,
+ * and decoding by that tag is the obvious approach. It does not survive the move to gRPC:
+ * `simulateTransaction` returns BCS bytes with no type information, so the tag is an
+ * empty string on the transport this SDK targets. Every decode here is therefore driven
+ * by a schema declared alongside the Move call it belongs to, taken from the contract
+ * signature rather than from the response.
+ *
+ * @module VaultUtils
+ */
+
+import { bcs } from '@mysten/sui/bcs'
+import type { Transaction } from '@mysten/sui/transactions'
+import { normalizeStructTag } from '@mysten/sui/utils'
+import { devInspectTransaction } from '@naviprotocol/lending'
+import { throwVaultError } from './errors'
+import type { VaultReadOptions } from './types'
+
+/** Raw BCS bytes of one Move call's return values, in declaration order. */
+export type RawCommandReturn = Uint8Array[]
+
+/** Decodes one BCS-encoded Move return value. */
+export type Decoder<T> = (bytes: Uint8Array) => T
+
+/** Address used as the simulation sender when the caller has none. Needs no funds or key. */
+export const SIMULATION_SENDER = `0x${'0'.repeat(63)}1`
+
+/**
+ * Decoders for the Move types the vault's view functions return.
+ *
+ * Integers wider than 32 bits come back as `bigint`: RAY-scaled reward indices always
+ * exceed `Number.MAX_SAFE_INTEGER`, and share and asset amounts can.
+ */
+export const decode = {
+  bool: (bytes: Uint8Array) => bcs.Bool.parse(bytes),
+  u8: (bytes: Uint8Array) => bcs.U8.parse(bytes),
+  u16: (bytes: Uint8Array) => bcs.U16.parse(bytes),
+  u32: (bytes: Uint8Array) => bcs.U32.parse(bytes),
+  u64: (bytes: Uint8Array) => BigInt(bcs.U64.parse(bytes)),
+  u128: (bytes: Uint8Array) => BigInt(bcs.U128.parse(bytes)),
+  u256: (bytes: Uint8Array) => BigInt(bcs.U256.parse(bytes)),
+  address: (bytes: Uint8Array) => bcs.Address.parse(bytes),
+  /** `std::ascii::String` and `std::string::String` share the BCS layout of a string. */
+  string: (bytes: Uint8Array) => bcs.string().parse(bytes),
+  /**
+   * `Coin<T>` is `{ id: UID, balance: Balance<T> }` and both wrappers are single-field,
+   * so the layout is a 32-byte address followed by a `u64`.
+   */
+  coinBalance: (bytes: Uint8Array) =>
+    BigInt(bcs.struct('Coin', { id: bcs.Address, balance: bcs.U64 }).parse(bytes).balance)
+} as const
+
+/**
+ * Evaluates a read-only block and returns each Move call's raw return bytes, in command
+ * order. Calls that return nothing yield an empty array.
+ *
+ * Nothing is written on chain and no signature or funded account is required — only a
+ * sender address.
+ */
+export async function simulate(
+  tx: Transaction,
+  options?: VaultReadOptions & { sender?: string }
+): Promise<RawCommandReturn[]> {
+  const sender = options?.sender ?? SIMULATION_SENDER
+
+  let result
+  try {
+    result = await devInspectTransaction(options?.client, { transaction: tx, sender })
+  } catch (error) {
+    throwVaultError(error)
+  }
+
+  if (result.error) {
+    throwVaultError(result.error)
+  }
+
+  return (result.results ?? []).map((command) =>
+    (command.returnValues ?? []).map(([bytes]) => Uint8Array.from(bytes))
+  )
+}
+
+/**
+ * Decodes one command's return values against a schema.
+ *
+ * Throws when the command is missing or returned fewer values than the schema expects —
+ * a shape mismatch means the contract signature moved, and silently reading `undefined`
+ * would surface much later as a nonsensical balance.
+ */
+export function decodeCommand<const S extends readonly Decoder<unknown>[]>(
+  results: RawCommandReturn[],
+  commandIndex: number,
+  schema: S,
+  label: string
+): { [K in keyof S]: S[K] extends Decoder<infer T> ? T : never } {
+  const command = results[commandIndex]
+  if (!command) {
+    throw new Error(
+      `Simulation returned no result for ${label} (command ${commandIndex} of ${results.length}).`
+    )
+  }
+  if (command.length < schema.length) {
+    throw new Error(
+      `${label} returned ${command.length} value(s), expected ${schema.length}. ` +
+        `The contract signature may have changed.`
+    )
+  }
+  return schema.map((decoder, index) => decoder(command[index]!)) as {
+    [K in keyof S]: S[K] extends Decoder<infer T> ? T : never
+  }
+}
+
+/** Decodes a single-value command. */
+export function decodeOne<T>(
+  results: RawCommandReturn[],
+  commandIndex: number,
+  decoder: Decoder<T>,
+  label: string
+): T {
+  return decodeCommand(results, commandIndex, [decoder] as const, label)[0] as T
+}
+
+/** Gas a transaction would consume, in MIST. */
+export type GasEstimate = {
+  computationCost: bigint
+  storageCost: bigint
+  /** Refunded when storage this transaction frees is reclaimed. */
+  storageRebate: bigint
+  nonRefundableStorageFee: bigint
+  /** `computation + storage - rebate`. What the sender actually pays. */
+  netCost: bigint
+}
+
+function toBigInt(value: unknown): bigint {
+  if (typeof value === 'bigint') return value
+  if (typeof value === 'number' || typeof value === 'string') return BigInt(value)
+  return 0n
+}
+
+/**
+ * Estimates what a transaction would cost, by simulating it.
+ *
+ * Worth doing for vault blocks specifically: a deposit or withdrawal is `M + R + 1` Move
+ * calls and grows with the vault's market count, so the cost is not a constant an
+ * integrator can assume. Opening a new position costs noticeably more than topping up an
+ * existing one, because it creates a Receipt object and a ledger entry.
+ *
+ * Simulated gas is a projection, not a quote — it does not account for execution under
+ * contention or for a gas price change between simulation and submission.
+ */
+export async function estimateGas(
+  tx: Transaction,
+  options?: VaultReadOptions & { sender?: string }
+): Promise<GasEstimate> {
+  const sender = options?.sender ?? SIMULATION_SENDER
+
+  let result
+  try {
+    result = await devInspectTransaction(options?.client, { transaction: tx, sender })
+  } catch (error) {
+    throwVaultError(error)
+  }
+  if (result.error) throwVaultError(result.error)
+
+  // The effects type models gasUsed as a fixed struct, but the field arrives as strings
+  // over gRPC and as numbers over JSON-RPC, so read it loosely and coerce.
+  const used = ((result.effects as unknown as { gasUsed?: Record<string, unknown> })?.gasUsed ??
+    {}) as Record<string, unknown>
+  const computationCost = toBigInt(used.computationCost)
+  const storageCost = toBigInt(used.storageCost)
+  const storageRebate = toBigInt(used.storageRebate)
+
+  return {
+    computationCost,
+    storageCost,
+    storageRebate,
+    nonRefundableStorageFee: toBigInt(used.nonRefundableStorageFee),
+    netCost: computationCost + storageCost - storageRebate
+  }
+}
+
+/** Reads a `Coin` return value's balance, or `undefined` when it cannot be decoded. */
+export function tryDecodeCoinBalance(bytes: Uint8Array | undefined): bigint | undefined {
+  if (!bytes) return undefined
+  try {
+    return decode.coinBalance(bytes)
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Canonicalizes a Move type read out of on-chain state.
+ *
+ * `type_name::into_string` renders addresses WITHOUT the `0x` prefix, so a coin type
+ * read back from the chain looks like `549e8b…::cert::CERT`. That string is not a valid
+ * type argument: the gRPC transport rejects it outright with a protobuf `FIELD_INVALID`
+ * on `type_arguments`, and the failure surfaces as a transport error rather than a Move
+ * abort, so it does not look like a type problem at all. Every type string that comes
+ * from a view function must pass through here before being used in a `moveCall`.
+ */
+export function normalizeMoveType(value: string): string {
+  return normalizeStructTag(value.startsWith('0x') ? value : `0x${value}`)
+}
+
+/** Normalizes a Sui address to its padded, lowercase 32-byte form. */
+export function normalizeAddress(value: string): string {
+  const hex = value.startsWith('0x') ? value.slice(2) : value
+  return `0x${hex.toLowerCase().padStart(64, '0')}`
+}
+
+/** True when two ids refer to the same object regardless of padding or case. */
+export function isSameAddress(left: string, right: string): boolean {
+  return normalizeAddress(left) === normalizeAddress(right)
+}
+
+/**
+ * Converts a WAD-scaled rate to a percentage.
+ *
+ * Lossy — for display only. Never round-trip a fee or penalty through this.
+ */
+export function wadToPercent(wad: bigint): number {
+  const WAD_SCALE = 1_000_000_000_000_000_000n
+  // Scale to basis points in integer space before converting, so a large value cannot
+  // lose precision on the way through Number.
+  return Number((wad * 10_000n) / WAD_SCALE) / 100
+}
+
+/** Formats a native-decimals amount as a decimal string. Display only. */
+export function formatUnits(amount: bigint, decimals: number): string {
+  const negative = amount < 0n
+  const digits = (negative ? -amount : amount).toString().padStart(decimals + 1, '0')
+  const whole = digits.slice(0, digits.length - decimals)
+  const fraction = decimals === 0 ? '' : `.${digits.slice(digits.length - decimals)}`
+  return `${negative ? '-' : ''}${whole}${fraction}`
+}

--- a/packages/vault/src/withdraw.ts
+++ b/packages/vault/src/withdraw.ts
@@ -1,0 +1,139 @@
+/**
+ * Vault Withdrawals
+ *
+ * @module VaultWithdraw
+ */
+
+import { Transaction } from '@mysten/sui/transactions'
+import { getVaultConfig, MAX_U64, resolveVault } from './config'
+import { NaviVaultError } from './errors'
+import { getVaultLayout, selectHarvestableRules } from './layout'
+import { resolveMarket } from './market'
+import { appendOracleProloguePTB } from './oracle'
+import { appendFreshnessPTB, createTxContext, withdrawPTB } from './ptb'
+import { assertOperable } from './deposit'
+import { previewWithdraw } from './quote'
+import type { VaultBuildOptions, VaultIdentifier, WithdrawArgs } from './types'
+
+/**
+ * Builds a complete withdrawal transaction.
+ *
+ * Command order is fixed and each part is load-bearing:
+ *
+ * 1. oracle price update — `withdraw` takes `PriceOracle` immutably and cannot refresh
+ *    it, and NAVI's collateral valuation asserts freshness even for a debt-free vault.
+ *    Omitting this aborts 1502.
+ * 2. one `sync_market_balance` per registered market, Disabled ones included.
+ * 3. one `collect_reward` per active market reward rule.
+ * 4. `withdraw`, then the produced coin is transferred to the holder.
+ *
+ * The idle balance is drawn down first; `poolId` designates the source of the shortfall
+ * only. When idle covers the whole amount, no penalty applies regardless of routing.
+ *
+ * `maxShares` is required and must be non-zero — `0n` disables slippage protection
+ * entirely. Use {@link buildWithdrawTxWithPreview} to derive it automatically.
+ */
+export async function buildWithdrawTx(
+  args: WithdrawArgs,
+  options?: VaultBuildOptions & { updatePythPriceFeeds?: boolean }
+): Promise<Transaction> {
+  const config = await getVaultConfig(options)
+  const descriptor = resolveVault(args.vault, config)
+  const layout = options?.layout ?? (await getVaultLayout(descriptor, options))
+  const ctx = createTxContext(config, descriptor)
+  const fromDefault = args.fromDefault ?? true
+
+  assertOperable(layout, 'Withdrawal', config.package.expectedVaultVersion)
+
+  if (args.amount <= 0n) {
+    throw new NaviVaultError({
+      code: 10034,
+      name: 'E_INVALID_AMOUNT',
+      kind: 'user',
+      message: 'Withdrawal amount must be greater than zero.',
+      raw: String(args.amount)
+    })
+  }
+
+  if (args.maxShares <= 0n) {
+    throw new NaviVaultError({
+      code: 10040,
+      name: 'E_SLIPPAGE_EXCEEDED',
+      kind: 'user',
+      message:
+        'maxShares must be greater than zero. The contract treats 0 as "no limit", not "no ' +
+        'shares", so passing it would submit the withdrawal with slippage protection disabled. ' +
+        'Derive it with previewWithdraw, or use buildWithdrawTxWithPreview.',
+      raw: String(args.maxShares)
+    })
+  }
+
+  const market = resolveMarket(layout, { fromDefault, poolId: args.poolId })
+
+  const tx = new Transaction()
+  tx.setSenderIfNotSet(args.sender)
+
+  await appendOracleProloguePTB(tx, descriptor, options)
+  appendFreshnessPTB(tx, ctx, layout, selectHarvestableRules(layout, descriptor))
+
+  const [coin] = withdrawPTB(tx, ctx, {
+    market,
+    receipt: tx.object(args.receiptId),
+    amount: args.amount,
+    maxShares: args.maxShares,
+    fromDefault
+  })
+
+  if (coin) {
+    tx.transferObjects([coin], tx.pure.address(args.sender))
+  }
+
+  return tx
+}
+
+/**
+ * Simulates the withdrawal to derive `maxShares`, then builds it.
+ *
+ * Two round trips instead of one, in exchange for a slippage bound that accounts for the
+ * market penalty, ceiling rounding, idle-first routing and same-transaction fee accrual
+ * — none of which `convert_to_shares` models.
+ *
+ * Both calls read the layout; the second reuses the first's, so a market added between
+ * them is caught by the on-chain assertion rather than silently ignored.
+ */
+export async function buildWithdrawTxWithPreview(
+  args: Omit<WithdrawArgs, 'maxShares'>,
+  options?: VaultBuildOptions & { toleranceBps?: number; updatePythPriceFeeds?: boolean }
+): Promise<{ transaction: Transaction; maxShares: bigint; sharesBurned: bigint }> {
+  const config = await getVaultConfig(options)
+  const descriptor = resolveVault(args.vault, config)
+  const layout = options?.layout ?? (await getVaultLayout(descriptor, options))
+
+  const preview = await previewWithdraw(args, { ...options, layout })
+  const transaction = await buildWithdrawTx(
+    { ...args, maxShares: preview.maxShares },
+    { ...options, layout }
+  )
+
+  return { transaction, maxShares: preview.maxShares, sharesBurned: preview.sharesBurned }
+}
+
+/**
+ * Builds a full exit.
+ *
+ * Uses `fromDefault` with `MAX_U64`: the contract clamps the amount to the holder's
+ * maximum redeemable value, and the default market carries no penalty, so the
+ * shares-to-assets relationship stays linear.
+ *
+ * This normally clears the position exactly. The exception is the sole remaining holder:
+ * the virtual-share offset that protects against inflation attacks means redeeming the
+ * full asset balance would require burning `total_shares + VIRTUAL_SHARES`, which they do
+ * not have, so they may need a second withdrawal or leave a small remainder. Multi-holder
+ * exits are unaffected. Read the returned coin value rather than assuming either way.
+ */
+export async function buildExitAllTx(
+  args: { vault: VaultIdentifier; receiptId: string; sender: string },
+  options?: VaultBuildOptions & { toleranceBps?: number; updatePythPriceFeeds?: boolean }
+): Promise<{ transaction: Transaction; maxShares: bigint; sharesBurned: bigint }> {
+  return buildWithdrawTxWithPreview({ ...args, amount: MAX_U64, fromDefault: true }, options)
+}

--- a/packages/vault/tests/audit-regressions.test.ts
+++ b/packages/vault/tests/audit-regressions.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+import {
+  assertOperable,
+  findReceipts,
+  MAINNET_VAULT_CONFIG,
+  NaviVaultError,
+  parseVaultError,
+  ReceiptStruct
+} from '../src'
+import { usdcHighYieldLayout } from './fixtures'
+
+const VAULT_ID = '0x54359eb5d0e4364bd26989899fdb472f5594d1885e1f0d816ef4a066cab2ae4c'
+const OWNER = `0x${'a'.repeat(64)}`
+
+describe('pagination cannot loop forever', () => {
+  /** A transport that claims another page but never advances the cursor. */
+  function stuckClient(cursor: string | null) {
+    let calls = 0
+    const client = {
+      core: {
+        listOwnedObjects: async () => {
+          calls += 1
+          if (calls > 20) throw new Error('infinite pagination')
+          return {
+            objects: [
+              {
+                objectId: `0x${'1'.repeat(64)}`,
+                content: ReceiptStruct.serialize({
+                  id: `0x${'1'.repeat(64)}`,
+                  vault_address: VAULT_ID
+                }).toBytes()
+              }
+            ],
+            cursor,
+            hasNextPage: true
+          }
+        }
+      }
+    }
+    return { client: client as never, calls: () => calls }
+  }
+
+  it('stops when the transport reports another page but returns no cursor', async () => {
+    const { client, calls } = stuckClient(null)
+    const receipts = await findReceipts(OWNER, 'USDC', { client })
+    expect(receipts).toHaveLength(1)
+    expect(calls()).toBe(1)
+  })
+
+  it('stops when the transport keeps returning the cursor it was given', async () => {
+    // First page has no cursor to compare against, so it is fetched; the second returns
+    // the same cursor and must terminate rather than re-request it.
+    const { client, calls } = stuckClient('same-cursor')
+    const receipts = await findReceipts(OWNER, 'USDC', { client })
+    expect(calls()).toBeLessThanOrEqual(2)
+    expect(receipts.length).toBeGreaterThan(0)
+  })
+})
+
+describe('abort classification is consistent between SDK and chain', () => {
+  it('classifies E_MARKET_INVALID the same way whichever raised it', () => {
+    // market.ts pre-empts 10010 before building; the chain raises it too. A caller
+    // branching on `kind` must not see two different answers for one condition.
+    const fromChain = parseVaultError('MoveAbort(MoveLocation { ... }, 10010)')
+    expect(fromChain?.kind).toBe('outage')
+  })
+
+  it.each([
+    [10011, 'outage'],
+    [10036, 'outage'],
+    [1400, 'outage'],
+    [10010, 'outage'],
+    [10021, 'user'],
+    [1506, 'liquidity']
+  ])('code %i is %s', (code, kind) => {
+    expect(parseVaultError(`MoveAbort(MoveLocation { x }, ${code})`)?.kind).toBe(kind)
+  })
+})
+
+describe('assertOperable', () => {
+  const layout = usdcHighYieldLayout()
+
+  it('passes a live vault at the expected version', () => {
+    expect(() => assertOperable(layout, 'Deposit', 2)).not.toThrow()
+  })
+
+  it('rejects a paused vault', () => {
+    expect(() => assertOperable({ ...layout, paused: true }, 'Deposit', 2)).toThrow(/paused/)
+  })
+
+  it('rejects a vault whose contract version has drifted', () => {
+    // Every entrypoint aborts 10036 in this state; catching it here saves the gas.
+    try {
+      assertOperable({ ...layout, version: 3n }, 'Deposit', 2)
+      expect.unreachable()
+    } catch (error) {
+      expect(error).toBeInstanceOf(NaviVaultError)
+      expect((error as NaviVaultError).code).toBe(10036)
+      expect((error as NaviVaultError).kind).toBe('outage')
+    }
+  })
+
+  it('skips the version check when configuration declares none', () => {
+    expect(() => assertOperable({ ...layout, version: 99n }, 'Deposit', undefined)).not.toThrow()
+  })
+
+  it('is wired to the bundled snapshot', () => {
+    expect(MAINNET_VAULT_CONFIG.package.expectedVaultVersion).toBe(2)
+  })
+})

--- a/packages/vault/tests/config.test.ts
+++ b/packages/vault/tests/config.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+import {
+  configureVaultSdk,
+  getVaultConfig,
+  isZeroAddress,
+  MAINNET_VAULT_CONFIG,
+  NaviVaultError,
+  resolveVault
+} from '../src'
+
+describe('resolveVault', () => {
+  it('resolves by config key', () => {
+    expect(resolveVault('USDC_PRIME', MAINNET_VAULT_CONFIG).displayName).toBe('USDC Prime')
+  })
+
+  it('resolves by object id regardless of padding or case', () => {
+    const vault = MAINNET_VAULT_CONFIG.vaults[0]!
+    expect(resolveVault(vault.vault, MAINNET_VAULT_CONFIG).key).toBe(vault.key)
+    expect(
+      resolveVault(vault.vault.toUpperCase().replace('0X', '0x'), MAINNET_VAULT_CONFIG).key
+    ).toBe(vault.key)
+  })
+
+  it('passes a descriptor straight through', () => {
+    const vault = MAINNET_VAULT_CONFIG.vaults[0]!
+    expect(resolveVault(vault, MAINNET_VAULT_CONFIG)).toBe(vault)
+  })
+
+  it('lists the known keys when nothing matches', () => {
+    try {
+      resolveVault('NOPE', MAINNET_VAULT_CONFIG)
+      expect.unreachable()
+    } catch (error) {
+      expect(error).toBeInstanceOf(NaviVaultError)
+      expect((error as NaviVaultError).message).toContain('USDC_PRIME')
+    }
+  })
+})
+
+describe('configureVaultSdk', () => {
+  it('overrides the bundled snapshot and restores it', async () => {
+    const custom = { ...MAINNET_VAULT_CONFIG, vaults: [] }
+    configureVaultSdk(custom)
+    expect((await getVaultConfig()).vaults).toHaveLength(0)
+    configureVaultSdk(undefined)
+    expect((await getVaultConfig()).vaults.length).toBeGreaterThan(0)
+  })
+
+  it('lets a per-call config win over the global one', async () => {
+    const custom = { ...MAINNET_VAULT_CONFIG, vaults: [] }
+    expect((await getVaultConfig({ config: custom })).vaults).toHaveLength(0)
+  })
+})
+
+describe('isZeroAddress', () => {
+  it.each([
+    ['0x0', true],
+    [`0x${'0'.repeat(64)}`, true],
+    ['', true],
+    ['0x1', false]
+  ])('%s -> %s', (value, expected) => {
+    expect(isZeroAddress(value)).toBe(expected)
+  })
+})
+
+describe('bundled snapshot', () => {
+  it('keeps the call target and type identity distinct', () => {
+    // Interchanging these fails silently in both directions, so the snapshot must never
+    // collapse them to one value.
+    expect(MAINNET_VAULT_CONFIG.package.packageId).not.toBe(
+      MAINNET_VAULT_CONFIG.package.typePackageId
+    )
+  })
+
+  it('gives every vault exactly one default market', () => {
+    for (const vault of MAINNET_VAULT_CONFIG.vaults) {
+      expect(vault.markets.filter((market) => market.isDefault)).toHaveLength(1)
+    }
+  })
+
+  it('does not assume the default market is named main', () => {
+    // SUI Prime routes to vsui-sui, USDC Prime to sui-usdc. Hardcoding "main" breaks both.
+    const prime = MAINNET_VAULT_CONFIG.vaults.find((vault) => vault.key === 'SUI_PRIME')!
+    expect(prime.markets.find((market) => market.isDefault)!.name).not.toBe('main')
+  })
+
+  it('gives every harvestable rule a reward fund', () => {
+    for (const vault of MAINNET_VAULT_CONFIG.vaults) {
+      for (const rule of vault.rewardRules) {
+        if (!rule.mustCollectBeforeWithdraw) continue
+        expect(rule.rewardFund, `${vault.key} rule ${rule.index}`).toBeTruthy()
+        expect(rule.storage, `${vault.key} rule ${rule.index}`).toBeTruthy()
+        expect(rule.incentiveV3, `${vault.key} rule ${rule.index}`).toBeTruthy()
+      }
+    }
+  })
+
+  it('allows two vaults to share one coin type', () => {
+    // Which is why receipts must be attributed by vault_address, not by type.
+    const suiVaults = MAINNET_VAULT_CONFIG.vaults.filter((v) => v.coinType === '0x2::sui::SUI')
+    expect(suiVaults.length).toBeGreaterThan(1)
+  })
+})

--- a/packages/vault/tests/deposit-receipt.test.ts
+++ b/packages/vault/tests/deposit-receipt.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+import { NaviVaultError, NEW_POSITION, resolveDepositReceipt } from '../src'
+import { ReceiptStruct } from '../src'
+
+const SENDER = `0x${'a'.repeat(64)}`
+const VAULT = 'SUI_PRIME'
+const VAULT_ID = '0x01236ff6c66c0c668950f9702629b42f372bf478793d055d2a7eca15e0b0d1e7'
+
+/** Stub client returning the given receipts as owned objects. */
+function clientWith(receiptIds: string[]) {
+  return {
+    core: {
+      listOwnedObjects: async () => ({
+        objects: receiptIds.map((objectId) => ({
+          objectId,
+          content: ReceiptStruct.serialize({ id: objectId, vault_address: VAULT_ID }).toBytes()
+        })),
+        cursor: null,
+        hasNextPage: false
+      })
+    }
+  } as never
+}
+
+const receipt = (n: string) => `0x${n.repeat(64)}`
+
+/** Fails if touched — proves an explicit choice skips the lookup entirely. */
+const explodingClient = {
+  core: {
+    listOwnedObjects: async () => {
+      throw new Error('lookup should not happen')
+    }
+  }
+} as never
+
+describe('resolveDepositReceipt', () => {
+  it('mints a new position when the sender holds none', async () => {
+    const resolved = await resolveDepositReceipt(
+      { vault: VAULT, sender: SENDER },
+      { client: clientWith([]) }
+    )
+    expect(resolved).toBeUndefined()
+  })
+
+  it('tops up the existing position when the sender holds exactly one', async () => {
+    // Without this, every deposit opens a fresh position and abandons the previous one.
+    const resolved = await resolveDepositReceipt(
+      { vault: VAULT, sender: SENDER },
+      { client: clientWith([receipt('1')]) }
+    )
+    expect(resolved).toBe(receipt('1'))
+  })
+
+  it('refuses to guess when the sender holds several', async () => {
+    try {
+      await resolveDepositReceipt(
+        { vault: VAULT, sender: SENDER },
+        { client: clientWith([receipt('1'), receipt('2')]) }
+      )
+      expect.unreachable()
+    } catch (error) {
+      expect(error).toBeInstanceOf(NaviVaultError)
+      // The message has to be actionable: list them so the caller can paste one back.
+      expect((error as NaviVaultError).message).toContain(receipt('1'))
+      expect((error as NaviVaultError).message).toContain(receipt('2'))
+      // The message must name the way out, not just the problem.
+      expect((error as NaviVaultError).message).toContain("position: 'new'")
+      expect((error as NaviVaultError).kind).toBe('user')
+    }
+  })
+
+  it('honours an explicit position without looking anything up', async () => {
+    const resolved = await resolveDepositReceipt(
+      { vault: VAULT, sender: SENDER, position: receipt('9') },
+      { client: explodingClient }
+    )
+    expect(resolved).toBe(receipt('9'))
+  })
+
+  it("honours position: 'new' without looking anything up", async () => {
+    const resolved = await resolveDepositReceipt(
+      { vault: VAULT, sender: SENDER, position: NEW_POSITION },
+      { client: explodingClient }
+    )
+    expect(resolved).toBeUndefined()
+  })
+
+  it('ignores receipts belonging to a different vault', async () => {
+    // Receipt is not generic, so one type covers every vault; only vault_address separates them.
+    const foreign = {
+      core: {
+        listOwnedObjects: async () => ({
+          objects: [
+            {
+              objectId: receipt('7'),
+              content: ReceiptStruct.serialize({
+                id: receipt('7'),
+                vault_address: `0x${'f'.repeat(64)}`
+              }).toBytes()
+            }
+          ],
+          cursor: null,
+          hasNextPage: false
+        })
+      }
+    }
+    const resolved = await resolveDepositReceipt(
+      { vault: VAULT, sender: SENDER },
+      { client: foreign as never }
+    )
+    expect(resolved).toBeUndefined()
+  })
+})

--- a/packages/vault/tests/errors.test.ts
+++ b/packages/vault/tests/errors.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import { isProtocolOutage, NaviVaultError, parseVaultError } from '../src'
+
+const moveAbort = (module: string, code: number) =>
+  `MoveAbort(MoveLocation { module: ModuleId { address: 0x51ceca, name: Identifier("${module}") }, ` +
+  `function: 5, instruction: 42, function_name: Some("deposit") }, ${code}) in command 7`
+
+describe('parseVaultError', () => {
+  it('decodes a vault abort with its module', () => {
+    const decoded = parseVaultError(moveAbort('navi_vault', 10006))
+    expect(decoded?.name).toBe('E_MARKET_NOT_READ')
+    expect(decoded?.kind).toBe('user')
+    expect(decoded?.module).toBe('navi_vault')
+    expect(decoded?.code).toBe(10006)
+  })
+
+  it('classifies the lending version mismatch as an outage, not user error', () => {
+    const decoded = parseVaultError(moveAbort('version', 1400))
+    expect(decoded?.name).toBe('LENDING_INCORRECT_VERSION')
+    expect(decoded?.kind).toBe('outage')
+  })
+
+  it("separates lending's 1400 from the vault's own version error", () => {
+    // Both originate in a module named `version`; only the code distinguishes them.
+    expect(parseVaultError(moveAbort('version', 1400))?.name).toBe('LENDING_INCORRECT_VERSION')
+    expect(parseVaultError(moveAbort('version', 10036))?.name).toBe('E_INCORRECT_VERSION')
+  })
+
+  it('classifies reserve conditions as liquidity rather than bad input', () => {
+    expect(parseVaultError(moveAbort('validation', 1506))?.kind).toBe('liquidity')
+    expect(parseVaultError(moveAbort('validation', 1604))?.kind).toBe('liquidity')
+  })
+
+  it("separates the vault's insufficient balance from reserve illiquidity", () => {
+    expect(parseVaultError(moveAbort('navi_vault', 10002))?.kind).toBe('user')
+    expect(parseVaultError(moveAbort('validation', 1506))?.kind).toBe('liquidity')
+  })
+
+  it('marks a stale oracle price as transient', () => {
+    expect(parseVaultError(moveAbort('oracle', 1502))?.kind).toBe('transient')
+  })
+
+  it('accepts Error instances and plain strings alike', () => {
+    expect(parseVaultError(new Error(moveAbort('navi_vault', 10011)))?.name).toBe('E_PAUSED')
+    expect(parseVaultError({ error: moveAbort('navi_vault', 10011) })?.name).toBe('E_PAUSED')
+  })
+
+  it('reports unknown codes rather than guessing', () => {
+    const decoded = parseVaultError(moveAbort('navi_vault', 99999))
+    expect(decoded?.kind).toBe('unknown')
+    expect(decoded?.code).toBe(99999)
+  })
+
+  it('returns undefined for failures that carry no abort code', () => {
+    expect(parseVaultError(new Error('fetch failed: ECONNREFUSED'))).toBeUndefined()
+    expect(parseVaultError(undefined)).toBeUndefined()
+  })
+})
+
+describe('isProtocolOutage', () => {
+  it.each([
+    [1400, true],
+    [10011, true],
+    [1506, false],
+    [10021, false]
+  ])('code %i -> %s', (code, expected) => {
+    expect(isProtocolOutage(moveAbort('navi_vault', code))).toBe(expected)
+  })
+})
+
+describe('NaviVaultError', () => {
+  it('carries the classification onto the thrown error', () => {
+    const decoded = parseVaultError(moveAbort('navi_vault', 10040))!
+    const error = new NaviVaultError(decoded)
+    expect(error).toBeInstanceOf(Error)
+    expect(error.code).toBe(10040)
+    expect(error.kind).toBe('transient')
+    expect(error.abortName).toBe('E_SLIPPAGE_EXCEEDED')
+    expect(error.message).toContain('E_SLIPPAGE_EXCEEDED')
+  })
+})

--- a/packages/vault/tests/fixtures.ts
+++ b/packages/vault/tests/fixtures.ts
@@ -1,0 +1,84 @@
+import { MAINNET_VAULT_CONFIG, MarketStatus } from '../src'
+import type { MarketLayout, RewardRuleLayout, VaultDescriptor, VaultLayout } from '../src'
+
+export const CONFIG = MAINNET_VAULT_CONFIG
+
+export function descriptor(key: string): VaultDescriptor {
+  const found = CONFIG.vaults.find((vault) => vault.key === key)
+  if (!found) throw new Error(`no fixture vault ${key}`)
+  return found
+}
+
+export function market(
+  overrides: Partial<MarketLayout> & Pick<MarketLayout, 'poolId'>
+): MarketLayout {
+  return {
+    cap: 0n,
+    penalty: 20_000_000_000_000_000n,
+    loss: 0n,
+    status: MarketStatus.Active,
+    lastSyncAtMs: 0n,
+    storageId: `0x${'a'.repeat(64)}`,
+    assetId: 0,
+    incentiveV3Id: `0x${'b'.repeat(64)}`,
+    incentiveV2Id: `0x${'c'.repeat(64)}`,
+    currentBalance: 0n,
+    ...overrides
+  }
+}
+
+export function rule(
+  overrides: Partial<RewardRuleLayout> & Pick<RewardRuleLayout, 'index'>
+): RewardRuleLayout {
+  return {
+    naviPoolId: `0x${'0'.repeat(64)}`,
+    rewardCoinType: '0x2::sui::SUI',
+    incentiveRuleId: `0x${'0'.repeat(64)}`,
+    vaultRewardIndex: 0n,
+    lastHarvestAtMs: 0n,
+    isVaultNative: false,
+    rewardRate: 0n,
+    isActive: true,
+    totalRewardDeposited: 0n,
+    totalRewardDistributed: 0n,
+    ...overrides
+  }
+}
+
+/**
+ * Layout mirroring USDC High Yield: five markets and two rules, one of which is an
+ * inactive vault-native rule with zeroed ids. The most complex live shape.
+ */
+export function usdcHighYieldLayout(): VaultLayout {
+  const descriptorUsdc = descriptor('USDC')
+  return {
+    markets: descriptorUsdc.markets.map((entry) =>
+      market({
+        poolId: entry.pool,
+        storageId: entry.storage,
+        incentiveV3Id: entry.incentiveV3,
+        assetId: entry.assetId,
+        currentBalance: 1_000_000n
+      })
+    ),
+    rules: [
+      rule({
+        index: 0,
+        naviPoolId: descriptorUsdc.markets[0]!.pool,
+        rewardCoinType:
+          '0x549e8b69270defbfafd4f94e17ec44cdbdd99820b33bda2278dea3b9a32d3f55::cert::CERT',
+        isActive: true,
+        isVaultNative: false
+      }),
+      rule({ index: 1, isActive: false, isVaultNative: true })
+    ],
+    defaultMarket: descriptorUsdc.markets[0]!.pool,
+    paused: false,
+    version: 2n,
+    vaultCap: 10_000_000_000_000n,
+    managementFee: 0n,
+    performanceFee: 50_000_000_000_000_000n,
+    idleBalance: 500_000n,
+    totalShares: 5_000_000n
+  }
+}

--- a/packages/vault/tests/layout.live.test.ts
+++ b/packages/vault/tests/layout.live.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Live mainnet reads. Gated behind NAVI_LIVE_TESTS=1 so CI stays hermetic.
+ *
+ *   NAVI_LIVE_TESTS=1 pnpm --filter @naviprotocol/vault test
+ */
+import { createNaviSuiClient } from '@naviprotocol/lending'
+import { beforeAll, describe, expect, it } from 'vitest'
+import {
+  diffLayoutAgainstConfig,
+  getVaultLayout,
+  getVaultQuote,
+  MAINNET_VAULT_CONFIG,
+  MarketStatus,
+  resolveVault,
+  selectHarvestableRules,
+  sharePrice,
+  findReceipts
+} from '../src'
+import type { VaultLayout } from '../src'
+
+const runLiveTests = process.env.NAVI_LIVE_TESTS === '1'
+const client = runLiveTests ? createNaviSuiClient() : undefined
+const options = () => ({ client: client as never })
+
+const VAULT_KEYS = MAINNET_VAULT_CONFIG.vaults.map((vault) => vault.key)
+
+describe.skipIf(!runLiveTests)('getVaultLayout', () => {
+  const layouts = new Map<string, VaultLayout>()
+
+  beforeAll(async () => {
+    for (const key of VAULT_KEYS) {
+      layouts.set(key, await getVaultLayout(key, options()))
+    }
+  }, 120_000)
+
+  it.each(VAULT_KEYS)('%s decodes', (key) => {
+    const layout = layouts.get(key)!
+    expect(layout.markets.length).toBeGreaterThan(0)
+    expect(layout.version).toBeGreaterThan(0n)
+    for (const market of layout.markets) {
+      expect(market.poolId).toMatch(/^0x[0-9a-f]{64}$/)
+      expect([MarketStatus.Active, MarketStatus.Disabled]).toContain(market.status)
+    }
+  })
+
+  it.each(VAULT_KEYS)('%s matches the bundled snapshot', (key) => {
+    const descriptor = resolveVault(key, MAINNET_VAULT_CONFIG)
+    const issues = diffLayoutAgainstConfig(layouts.get(key)!, descriptor)
+    // A failure here means the snapshot has drifted from chain, which is the exact
+    // condition that makes transactions abort. It is a signal to re-dump, not a flake.
+    expect(issues, issues.join('\n')).toEqual([])
+  })
+
+  it.each(VAULT_KEYS)('%s resolves a reward fund for every harvestable rule', (key) => {
+    const descriptor = resolveVault(key, MAINNET_VAULT_CONFIG)
+    expect(() => selectHarvestableRules(layouts.get(key)!, descriptor)).not.toThrow()
+  })
+
+  it('USDC High Yield carries the inactive vault-native rule', () => {
+    const layout = layouts.get('USDC')!
+    const native = layout.rules.find((rule) => rule.isVaultNative)
+    expect(native).toBeDefined()
+    // Vault-native rules are exempt from the harvest requirement even when active.
+    expect(selectHarvestableRules(layout, resolveVault('USDC', MAINNET_VAULT_CONFIG)).length).toBe(
+      layout.rules.filter((rule) => rule.isActive && !rule.isVaultNative).length
+    )
+  })
+
+  it('the Prime vaults have no reward rules at all', () => {
+    expect(layouts.get('SUI_PRIME')!.rules).toEqual([])
+    expect(layouts.get('USDC_PRIME')!.rules).toEqual([])
+  })
+
+  it('the default market is not always named main', () => {
+    const prime = layouts.get('SUI_PRIME')!
+    const descriptor = resolveVault('SUI_PRIME', MAINNET_VAULT_CONFIG)
+    const main = descriptor.markets.find((market) => market.name === 'main')
+    expect(main?.pool).not.toBe(prime.defaultMarket)
+  })
+})
+
+describe.skipIf(!runLiveTests)('getVaultQuote', () => {
+  it.each(VAULT_KEYS)(
+    '%s prices against a synchronized snapshot',
+    async (key) => {
+      const quote = await getVaultQuote(key, options())
+      expect(quote.totalAssets).toBeGreaterThan(0n)
+      expect(quote.totalShares).toBeGreaterThan(0n)
+
+      // totalAssets is idle + the sum of the market balances, by definition.
+      const summed = Object.values(quote.marketBalances).reduce((a, b) => a + b, quote.idleBalance)
+      expect(summed).toBe(quote.totalAssets)
+
+      const price = sharePrice(quote)
+      expect(price).toBeGreaterThan(0)
+      // Share price only grows from 1; a value below it would mean loss beyond yield.
+      expect(price).toBeGreaterThanOrEqual(0.9)
+    },
+    60_000
+  )
+
+  it('reports headroom against the vault cap', async () => {
+    const quote = await getVaultQuote('USDC', options())
+    expect(quote.depositHeadroom).not.toBeNull()
+    expect(quote.depositHeadroom!).toBeGreaterThanOrEqual(0n)
+  }, 60_000)
+})
+
+describe.skipIf(!runLiveTests)('findReceipts', () => {
+  it('returns nothing for an address that holds none, without erroring', async () => {
+    const receipts = await findReceipts(`0x${'0'.repeat(63)}1`, 'USDC', options())
+    expect(receipts).toEqual([])
+  }, 60_000)
+})

--- a/packages/vault/tests/market.test.ts
+++ b/packages/vault/tests/market.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import {
+  findMarket,
+  getDefaultMarket,
+  marketDepositHeadroom,
+  MarketStatus,
+  NaviVaultError,
+  resolveDepositMarket,
+  resolveMarket,
+  ZERO_ADDRESS
+} from '../src'
+import { market, usdcHighYieldLayout } from './fixtures'
+
+const layout = usdcHighYieldLayout()
+const defaultPool = layout.defaultMarket
+const otherPool = layout.markets[1]!.poolId
+
+describe('findMarket / getDefaultMarket', () => {
+  it('matches regardless of address padding', () => {
+    const unpadded = defaultPool.replace(/^0x0+/, '0x')
+    expect(findMarket(layout, unpadded)?.poolId).toBe(defaultPool)
+  })
+
+  it('treats an unset default market as no market', () => {
+    expect(getDefaultMarket({ ...layout, defaultMarket: ZERO_ADDRESS })).toBeUndefined()
+  })
+})
+
+describe('resolveMarket', () => {
+  it('returns the default market when fromDefault is set', () => {
+    expect(resolveMarket(layout, { fromDefault: true }).poolId).toBe(defaultPool)
+  })
+
+  it('rejects a non-default pool under fromDefault', () => {
+    // The contract aborts 10022 here; failing at build time says why.
+    expect(() => resolveMarket(layout, { fromDefault: true, poolId: otherPool })).toThrow(
+      NaviVaultError
+    )
+  })
+
+  it('allows any registered market when fromDefault is off', () => {
+    expect(resolveMarket(layout, { fromDefault: false, poolId: otherPool }).poolId).toBe(otherPool)
+  })
+
+  it('allows withdrawing from a Disabled market', () => {
+    // Status is not checked on withdrawal, so a market being wound down stays drainable.
+    const winding = {
+      ...layout,
+      markets: layout.markets.map((entry) =>
+        entry.poolId === otherPool ? { ...entry, status: MarketStatus.Disabled } : entry
+      )
+    }
+    expect(resolveMarket(winding, { fromDefault: false, poolId: otherPool }).poolId).toBe(otherPool)
+  })
+
+  it('names the registered markets when the pool is unknown', () => {
+    try {
+      resolveMarket(layout, { fromDefault: false, poolId: `0x${'e'.repeat(64)}` })
+      expect.unreachable()
+    } catch (error) {
+      expect((error as NaviVaultError).message).toContain(defaultPool)
+    }
+  })
+})
+
+describe('resolveDepositMarket', () => {
+  it('returns the default market', () => {
+    expect(resolveDepositMarket(layout)?.poolId).toBe(defaultPool)
+  })
+
+  it('returns undefined when deposits go to idle', () => {
+    expect(resolveDepositMarket({ ...layout, defaultMarket: ZERO_ADDRESS })).toBeUndefined()
+  })
+
+  it('refuses to deposit into a Disabled default market', () => {
+    const disabled = {
+      ...layout,
+      markets: layout.markets.map((entry) =>
+        entry.poolId === defaultPool ? { ...entry, status: MarketStatus.Disabled } : entry
+      )
+    }
+    expect(() => resolveDepositMarket(disabled)).toThrow(NaviVaultError)
+  })
+})
+
+describe('marketDepositHeadroom', () => {
+  it('reports null for an uncapped market', () => {
+    expect(marketDepositHeadroom(market({ poolId: '0x1', cap: 0n }))).toBeNull()
+  })
+
+  it('reports the remaining room', () => {
+    expect(marketDepositHeadroom(market({ poolId: '0x1', cap: 100n, currentBalance: 40n }))).toBe(
+      60n
+    )
+  })
+
+  it('clamps to zero rather than going negative', () => {
+    expect(marketDepositHeadroom(market({ poolId: '0x1', cap: 100n, currentBalance: 140n }))).toBe(
+      0n
+    )
+  })
+})

--- a/packages/vault/tests/oracle.test.ts
+++ b/packages/vault/tests/oracle.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { toLendingOptions } from '../src'
+import { usdcHighYieldLayout } from './fixtures'
+
+describe('toLendingOptions', () => {
+  it('drops vault-only keys before they reach lending', () => {
+    // lending derives its cache key with JSON.stringify over the argument list, and
+    // JSON.stringify throws on a BigInt. `layout` is full of them, so forwarding a vault
+    // options object wholesale fails inside lending, nowhere near the call site.
+    const narrowed = toLendingOptions({
+      client: 'client' as never,
+      env: 'prod',
+      layout: usdcHighYieldLayout()
+    })
+
+    expect(narrowed).not.toHaveProperty('layout')
+    expect(() => JSON.stringify(narrowed)).not.toThrow()
+  })
+
+  it('keeps every key lending understands', () => {
+    const narrowed = toLendingOptions({
+      client: 'client' as never,
+      env: 'dev',
+      cacheTime: 1000,
+      disableCache: true,
+      services: { naviOpenApi: { baseUrl: 'https://example.test' } }
+    })
+
+    expect(narrowed).toMatchObject({
+      client: 'client',
+      env: 'dev',
+      cacheTime: 1000,
+      disableCache: true
+    })
+    expect(narrowed).toHaveProperty('services')
+  })
+
+  it('omits undefined rather than emitting explicit nulls into the cache key', () => {
+    expect(Object.keys(toLendingOptions({ env: 'prod' })!)).toEqual(['env'])
+  })
+
+  it('passes undefined through', () => {
+    expect(toLendingOptions(undefined)).toBeUndefined()
+  })
+
+  it('survives a layout carrying BigInt amounts', () => {
+    const layout = usdcHighYieldLayout()
+    expect(() => JSON.stringify(layout)).toThrow(/BigInt/)
+    expect(() => JSON.stringify(toLendingOptions({ layout }))).not.toThrow()
+  })
+})

--- a/packages/vault/tests/ptb.test.ts
+++ b/packages/vault/tests/ptb.test.ts
@@ -1,0 +1,189 @@
+import { Transaction } from '@mysten/sui/transactions'
+import { describe, expect, it } from 'vitest'
+import {
+  appendCollectRewardsPTB,
+  appendFreshnessPTB,
+  appendSyncMarketsPTB,
+  claimRewardPTB,
+  createTxContext,
+  depositPTB,
+  selectHarvestableRules,
+  withdrawPTB
+} from '../src'
+import { CONFIG, descriptor, usdcHighYieldLayout } from './fixtures'
+
+const USDC = descriptor('USDC')
+const ctx = createTxContext(CONFIG, USDC)
+const layout = usdcHighYieldLayout()
+
+type MoveCall = {
+  $kind: string
+  MoveCall?: {
+    package: string
+    module: string
+    function: string
+    typeArguments: string[]
+    arguments: unknown[]
+  }
+}
+
+function commands(tx: Transaction): MoveCall[] {
+  return tx.getData().commands as unknown as MoveCall[]
+}
+
+function moveCalls(tx: Transaction) {
+  return commands(tx)
+    .filter((command) => command.MoveCall)
+    .map((command) => command.MoveCall!)
+}
+
+describe('appendSyncMarketsPTB', () => {
+  it('emits one sync per registered market, Disabled ones included', () => {
+    const tx = new Transaction()
+    appendSyncMarketsPTB(tx, ctx, layout)
+
+    const calls = moveCalls(tx)
+    expect(calls).toHaveLength(layout.markets.length)
+    expect(calls.every((call) => call.function === 'sync_market_balance')).toBe(true)
+    expect(calls[0]!.module).toBe('navi_vault')
+    expect(calls[0]!.typeArguments).toEqual([USDC.coinType])
+  })
+
+  it('targets the LATEST package, not the type-identity package', () => {
+    const tx = new Transaction()
+    appendSyncMarketsPTB(tx, ctx, layout)
+    const call = moveCalls(tx)[0]!
+    expect(call.package).toBe(CONFIG.package.packageId)
+    expect(call.package).not.toBe(CONFIG.package.typePackageId)
+  })
+
+  it('takes market objects from the layout, not from configuration', () => {
+    // The contract validates these against what it recorded and aborts 10017 otherwise,
+    // so a config value that has drifted must not win.
+    const drifted = {
+      ...layout,
+      markets: layout.markets.map((market, index) =>
+        index === 0 ? { ...market, storageId: `0x${'9'.repeat(64)}` } : market
+      )
+    }
+    const tx = new Transaction()
+    appendSyncMarketsPTB(tx, ctx, drifted)
+    // Arguments are Input references, so resolve them through the input table.
+    expect(JSON.stringify(tx.getData().inputs)).toContain('9'.repeat(64))
+  })
+})
+
+describe('appendCollectRewardsPTB', () => {
+  it('harvests only active market rules', () => {
+    const tx = new Transaction()
+    appendCollectRewardsPTB(tx, ctx, selectHarvestableRules(layout, USDC))
+
+    const calls = moveCalls(tx)
+    // Rule 1 is inactive and vault-native; only rule 0 is harvestable.
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.function).toBe('collect_reward')
+    expect(calls[0]!.typeArguments).toEqual([USDC.coinType, layout.rules[0]!.rewardCoinType])
+  })
+
+  it('emits nothing for a vault with no rules', () => {
+    const prime = descriptor('SUI_PRIME')
+    const primeLayout = { ...layout, rules: [] }
+    const tx = new Transaction()
+    appendCollectRewardsPTB(
+      tx,
+      createTxContext(CONFIG, prime),
+      selectHarvestableRules(primeLayout, prime)
+    )
+    expect(moveCalls(tx)).toHaveLength(0)
+  })
+})
+
+describe('appendFreshnessPTB', () => {
+  it('orders every sync before every harvest', () => {
+    const tx = new Transaction()
+    appendFreshnessPTB(tx, ctx, layout, selectHarvestableRules(layout, USDC))
+
+    const names = moveCalls(tx).map((call) => call.function)
+    expect(names).toEqual([
+      ...Array(layout.markets.length).fill('sync_market_balance'),
+      'collect_reward'
+    ])
+  })
+})
+
+describe('depositPTB', () => {
+  it('wraps a new position in option::none and an existing one in option::some', () => {
+    const fresh = new Transaction()
+    depositPTB(fresh, ctx, {
+      market: layout.markets[0]!,
+      coin: fresh.splitCoins(fresh.gas, [fresh.pure.u64(1n)])[0]!,
+      amount: 1n
+    })
+    expect(moveCalls(fresh).map((c) => c.function)).toContain('none')
+
+    const existing = new Transaction()
+    depositPTB(existing, ctx, {
+      market: layout.markets[0]!,
+      coin: existing.splitCoins(existing.gas, [existing.pure.u64(1n)])[0]!,
+      amount: 1n,
+      receipt: existing.object(`0x${'d'.repeat(64)}`)
+    })
+    expect(moveCalls(existing).map((c) => c.function)).toContain('some')
+  })
+
+  it('types the option by the ORIGINAL package — Receipt is not generic', () => {
+    const tx = new Transaction()
+    depositPTB(tx, ctx, {
+      market: layout.markets[0]!,
+      coin: tx.splitCoins(tx.gas, [tx.pure.u64(1n)])[0]!,
+      amount: 1n
+    })
+    const option = moveCalls(tx).find((call) => call.function === 'none')!
+    expect(option.typeArguments).toEqual([`${CONFIG.package.typePackageId}::navi_vault::Receipt`])
+  })
+
+  it('passes deposit arguments in the contract order', () => {
+    const tx = new Transaction()
+    depositPTB(tx, ctx, {
+      market: layout.markets[0]!,
+      coin: tx.splitCoins(tx.gas, [tx.pure.u64(123n)])[0]!,
+      amount: 123n
+    })
+    const deposit = moveCalls(tx).find((call) => call.function === 'deposit')!
+    // (vault, receipt_opt, clock, storage, pool, coin, amount, incentive_v2, incentive_v3)
+    expect(deposit.arguments).toHaveLength(9)
+    expect(deposit.typeArguments).toEqual([USDC.coinType])
+  })
+})
+
+describe('withdrawPTB', () => {
+  it('passes withdraw arguments in the contract order', () => {
+    const tx = new Transaction()
+    withdrawPTB(tx, ctx, {
+      market: layout.markets[0]!,
+      receipt: tx.object(`0x${'d'.repeat(64)}`),
+      amount: 100n,
+      maxShares: 110n,
+      fromDefault: true
+    })
+    const call = moveCalls(tx)[0]!
+    // (vault, receipt, clock, oracle, storage, pool, amount, max_shares, from_default,
+    //  incentive_v2, incentive_v3, system_state)
+    expect(call.function).toBe('withdraw')
+    expect(call.arguments).toHaveLength(12)
+  })
+})
+
+describe('claimRewardPTB', () => {
+  it('carries both the vault coin type and the reward coin type', () => {
+    const tx = new Transaction()
+    claimRewardPTB(tx, ctx, {
+      receipt: tx.object(`0x${'d'.repeat(64)}`),
+      rewardCoinType: '0x2::sui::SUI'
+    })
+    const call = moveCalls(tx)[0]!
+    expect(call.function).toBe('claim_reward')
+    expect(call.typeArguments).toEqual([USDC.coinType, '0x2::sui::SUI'])
+    expect(call.arguments).toHaveLength(3)
+  })
+})

--- a/packages/vault/tests/type-compat/public-surface.ts
+++ b/packages/vault/tests/type-compat/public-surface.ts
@@ -1,0 +1,138 @@
+/**
+ * Compile-only assertions against the BUILT `dist/index.d.ts`, not the source.
+ *
+ * Run by `pnpm test:types`. Nothing here executes; the file exists so that a change to
+ * the public type surface fails the build rather than a consumer's.
+ */
+import type { Transaction } from '@mysten/sui/transactions'
+import {
+  buildDepositTx,
+  buildExitAllTx,
+  buildWithdrawTx,
+  buildWithdrawTxWithPreview,
+  decode,
+  findReceipts,
+  getVaultLayout,
+  getVaultQuote,
+  MAINNET_VAULT_CONFIG,
+  MarketStatus,
+  parseVaultError,
+  previewWithdraw,
+  sharePrice,
+  MAX_U64,
+  WAD
+} from '@naviprotocol/vault'
+import type {
+  MarketLayout,
+  VaultConfig,
+  VaultError,
+  VaultLayout,
+  VaultPosition,
+  VaultQuote,
+  VaultReceipt,
+  WithdrawPreview
+} from '@naviprotocol/vault'
+
+declare const client: never
+declare const sender: string
+declare const receiptId: string
+
+/** Raw on-chain integers are bigint, never number or string. */
+export async function amountsAreBigint(): Promise<void> {
+  const layout: VaultLayout = await getVaultLayout('USDC', { client })
+  const cap: bigint = layout.vaultCap
+  const shares: bigint = layout.totalShares
+  const fee: bigint = layout.managementFee
+
+  const market: MarketLayout | undefined = layout.markets[0]
+  const balance: bigint | undefined = market?.currentBalance
+  const lastSync: bigint | undefined = market?.lastSyncAtMs
+  const assetId: number | undefined = market?.assetId
+
+  void [cap, shares, fee, balance, lastSync, assetId]
+}
+
+/** Quotes expose bigint amounts and a nullable headroom. */
+export async function quoteShape(): Promise<void> {
+  const quote: VaultQuote = await getVaultQuote('SUI', { client })
+  const total: bigint = quote.totalAssets
+  const headroom: bigint | null = quote.depositHeadroom
+  const price: number = sharePrice(quote)
+  void [total, headroom, price]
+}
+
+/** Builders return a Sui v2 Transaction. */
+export async function buildersReturnTransactions(): Promise<void> {
+  const deposit: Transaction = await buildDepositTx(
+    { vault: 'USDC', amount: 1_000_000n, sender },
+    { client }
+  )
+  // position accepts a receipt id or the 'new' sentinel, and nothing else.
+  const explicit: Transaction = await buildDepositTx(
+    { vault: 'USDC', amount: 1_000_000n, sender, position: receiptId },
+    { client }
+  )
+  const fresh: Transaction = await buildDepositTx(
+    { vault: 'USDC', amount: 1_000_000n, sender, position: 'new' },
+    { client }
+  )
+  void [explicit, fresh]
+  const withdraw: Transaction = await buildWithdrawTx(
+    { vault: 'USDC', receiptId, amount: 1_000_000n, sender, maxShares: 1_100_000n },
+    { client }
+  )
+  const previewed = await buildWithdrawTxWithPreview(
+    { vault: 'USDC', receiptId, amount: 1_000_000n, sender },
+    { client }
+  )
+  const exit = await buildExitAllTx({ vault: 'USDC', receiptId, sender }, { client })
+
+  const tx1: Transaction = previewed.transaction
+  const tx2: Transaction = exit.transaction
+  const bound: bigint = previewed.maxShares
+  void [deposit, withdraw, tx1, tx2, bound]
+}
+
+/** previewWithdraw reports the contract's own figure plus a derived bound. */
+export async function previewShape(): Promise<void> {
+  const preview: WithdrawPreview = await previewWithdraw(
+    { vault: 'SUI', receiptId, amount: MAX_U64, sender },
+    { client }
+  )
+  const burned: bigint = preview.sharesBurned
+  const out: bigint | undefined = preview.amountOut
+  void [burned, out]
+}
+
+/** Receipts carry the attribution field, since the type alone cannot identify a vault. */
+export async function receiptShape(): Promise<void> {
+  const receipts: VaultReceipt[] = await findReceipts(sender, 'SUI', { client })
+  const vaultAddress: string | undefined = receipts[0]?.vaultAddress
+  void vaultAddress
+}
+
+/** Decoded aborts carry a classification a caller can branch on. */
+export function errorShape(): void {
+  const decoded: VaultError | undefined = parseVaultError('abort')
+  if (decoded?.kind === 'outage') {
+    const code: number = decoded.code
+    void code
+  }
+}
+
+/** Constants keep their bigint type through the barrel. */
+export function constantsAreBigint(): void {
+  const wad: bigint = WAD
+  const max: bigint = MAX_U64
+  const config: VaultConfig = MAINNET_VAULT_CONFIG
+  const active: MarketStatus = MarketStatus.Active
+  const u64: (bytes: Uint8Array) => bigint = decode.u64
+  void [wad, max, config, active, u64]
+}
+
+/** Positions are per receipt, never merged. */
+export function positionShape(positions: VaultPosition[]): void {
+  const id: string | undefined = positions[0]?.receiptId
+  const shares: bigint | undefined = positions[0]?.shares
+  void [id, shares]
+}

--- a/packages/vault/tests/utils.test.ts
+++ b/packages/vault/tests/utils.test.ts
@@ -1,0 +1,135 @@
+import { bcs } from '@mysten/sui/bcs'
+import { describe, expect, it } from 'vitest'
+import {
+  decode,
+  decodeCommand,
+  decodeOne,
+  formatUnits,
+  isSameAddress,
+  normalizeAddress,
+  normalizeMoveType,
+  ReceiptStruct,
+  tryDecodeCoinBalance,
+  wadToPercent,
+  WAD
+} from '../src'
+
+describe('decode', () => {
+  it('returns u64 and u256 as bigint', () => {
+    // RAY-scaled reward indices routinely exceed Number.MAX_SAFE_INTEGER.
+    const big = 12_345_678_901_234_567_890n
+    expect(decode.u64(bcs.U64.serialize(big).toBytes())).toBe(big)
+    const ray = 10n ** 27n
+    expect(decode.u256(bcs.U256.serialize(ray).toBytes())).toBe(ray)
+  })
+
+  it('decodes bool, u8 and address', () => {
+    expect(decode.bool(bcs.Bool.serialize(true).toBytes())).toBe(true)
+    expect(decode.u8(bcs.U8.serialize(1).toBytes())).toBe(1)
+    const address = `0x${'1'.repeat(64)}`
+    expect(decode.address(bcs.Address.serialize(address).toBytes())).toBe(address)
+  })
+
+  it('decodes an ascii::String payload', () => {
+    expect(decode.string(bcs.string().serialize('0x2::sui::SUI').toBytes())).toBe('0x2::sui::SUI')
+  })
+
+  it('reads the balance out of a returned Coin', () => {
+    const bytes = bcs
+      .struct('Coin', { id: bcs.Address, balance: bcs.U64 })
+      .serialize({ id: `0x${'a'.repeat(64)}`, balance: 42n })
+      .toBytes()
+    expect(decode.coinBalance(bytes)).toBe(42n)
+    expect(tryDecodeCoinBalance(bytes)).toBe(42n)
+  })
+
+  it('returns undefined rather than throwing on an undecodable coin', () => {
+    expect(tryDecodeCoinBalance(undefined)).toBeUndefined()
+    expect(tryDecodeCoinBalance(new Uint8Array([1]))).toBeUndefined()
+  })
+})
+
+describe('decodeCommand', () => {
+  const results = [
+    [bcs.U64.serialize(7n).toBytes(), bcs.Address.serialize(`0x${'2'.repeat(64)}`).toBytes()]
+  ]
+
+  it('decodes positionally against a schema', () => {
+    // The gRPC simulate response carries no Move type strings, so position is all there
+    // is — the schema has to come from the contract signature.
+    const [count, address] = decodeCommand(results, 0, [decode.u64, decode.address], 'probe')
+    expect(count).toBe(7n)
+    expect(address).toBe(`0x${'2'.repeat(64)}`)
+  })
+
+  it('reads a single-value command', () => {
+    expect(decodeOne(results, 0, decode.u64, 'probe')).toBe(7n)
+  })
+
+  it('fails loudly when the command is missing', () => {
+    expect(() => decodeOne(results, 5, decode.u64, 'probe')).toThrow(/no result/)
+  })
+
+  it('fails loudly when the arity does not match the schema', () => {
+    // A signature change must not be read as a silently short result.
+    expect(() =>
+      decodeCommand(results, 0, [decode.u64, decode.address, decode.u64], 'probe')
+    ).toThrow(/expected 3/)
+  })
+})
+
+describe('ReceiptStruct', () => {
+  it('round-trips the two-address layout', () => {
+    const value = { id: `0x${'1'.repeat(64)}`, vault_address: `0x${'2'.repeat(64)}` }
+    const bytes = ReceiptStruct.serialize(value).toBytes()
+    expect(bytes).toHaveLength(64)
+    expect(ReceiptStruct.parse(bytes).vault_address).toBe(value.vault_address)
+  })
+})
+
+describe('normalizeMoveType', () => {
+  it('restores the 0x prefix that type_name strips', () => {
+    // get_rule_info returns the reward coin type via type_name::into_string, which
+    // renders the address bare. Passing it straight back as a type argument is rejected
+    // by the gRPC transport with a protobuf FIELD_INVALID, not a Move abort — so it does
+    // not read as a type problem at the call site.
+    const bare = '549e8b69270defbfafd4f94e17ec44cdbdd99820b33bda2278dea3b9a32d3f55::cert::CERT'
+    expect(normalizeMoveType(bare)).toBe(`0x${bare}`)
+  })
+
+  it('is idempotent on an already-prefixed type', () => {
+    const prefixed = '0x2::sui::SUI'
+    expect(normalizeMoveType(prefixed)).toBe(normalizeMoveType(normalizeMoveType(prefixed)))
+  })
+
+  it('canonicalizes short addresses', () => {
+    expect(normalizeMoveType('0x2::sui::SUI')).toBe(normalizeMoveType('2::sui::SUI'))
+  })
+})
+
+describe('address helpers', () => {
+  it('pads and lowercases', () => {
+    expect(normalizeAddress('0x2')).toBe(`0x${'0'.repeat(63)}2`)
+    expect(normalizeAddress('0xAB')).toBe(`0x${'0'.repeat(62)}ab`)
+  })
+
+  it('compares across paddings', () => {
+    expect(isSameAddress('0x2', `0x${'0'.repeat(63)}2`)).toBe(true)
+    expect(isSameAddress('0x2', '0x3')).toBe(false)
+  })
+})
+
+describe('display formatting', () => {
+  it('converts WAD rates to percent', () => {
+    expect(wadToPercent(WAD)).toBe(100)
+    expect(wadToPercent(WAD / 20n)).toBe(5)
+    expect(wadToPercent(20_000_000_000_000_000n)).toBe(2)
+  })
+
+  it('formats native-decimal amounts', () => {
+    expect(formatUnits(1_000_000n, 6)).toBe('1.000000')
+    expect(formatUnits(1n, 9)).toBe('0.000000001')
+    expect(formatUnits(-1_500_000n, 6)).toBe('-1.500000')
+    expect(formatUnits(42n, 0)).toBe('42')
+  })
+})

--- a/packages/vault/tests/writepath.live.test.ts
+++ b/packages/vault/tests/writepath.live.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Live write-path simulation. Gated behind NAVI_LIVE_TESTS=1.
+ *
+ *   NAVI_LIVE_TESTS=1 pnpm --filter @naviprotocol/vault test
+ *
+ * Runs the deposit, withdrawal and reward-claim blocks through the Move VM against real
+ * mainnet state. Nothing is signed and nothing moves; simulation discards the mutable
+ * references. This is as far as the transaction builders can be verified without
+ * submitting real funds, and it is what caught the unprefixed-type-argument bug that
+ * every offline test missed.
+ *
+ * The holder and receipts below were discovered from `DepositEvent` on 2026-08-07. They
+ * belong to third parties and may be transferred or burned; if a case starts failing
+ * with E_RECEIPT_NOT_FOUND, re-discover a holder rather than assuming a regression.
+ */
+import { createNaviSuiClient } from '@naviprotocol/lending'
+import { describe, expect, it } from 'vitest'
+import {
+  buildDepositTx,
+  estimateGas,
+  getVaultPositions,
+  MAX_U64,
+  parseVaultError,
+  previewClaimReward,
+  previewWithdraw,
+  simulate
+} from '../src'
+
+const runLiveTests = process.env.NAVI_LIVE_TESTS === '1'
+const client = runLiveTests ? (createNaviSuiClient() as never) : (undefined as never)
+const options = () => ({ client })
+
+const HOLDER = '0xb63f43844a683e4be1157fb456c0cc8d38dedeb8b6c54d25d0b57662f144813e'
+const CERT = '0x549e8b69270defbfafd4f94e17ec44cdbdd99820b33bda2278dea3b9a32d3f55::cert::CERT'
+
+const CASES = [
+  {
+    key: 'SUI_PRIME',
+    label: 'no reward rules',
+    receiptId: '0x102e8b94337fa702e118c9a3005ba45c938fd044c2523f6b695e8bea72c0ae27',
+    /** 2 sync + option::none + splitCoins + deposit + transfer */
+    expectedCommands: 6
+  },
+  {
+    key: 'SUI',
+    label: 'one active market reward rule',
+    receiptId: '0x107f1a0c5e11eeaefaed03c15de0659dc1396d043811a24dd93dba193da741f0',
+    /** 3 sync + 1 collect_reward + option::none + splitCoins + deposit + transfer */
+    expectedCommands: 8
+  }
+] as const
+
+describe.skipIf(!runLiveTests).each(CASES)('$key ($label)', (testCase) => {
+  it('deposit simulates against live state', async () => {
+    // position: 'new' keeps the command count deterministic regardless of how many
+    // receipts the third-party holder currently has. Reuse is covered by unit tests.
+    const tx = await buildDepositTx(
+      { vault: testCase.key, amount: 1_000_000_000n, sender: HOLDER, position: 'new' },
+      options()
+    )
+    expect(tx.getData().commands).toHaveLength(testCase.expectedCommands)
+    await expect(simulate(tx, { ...options(), sender: HOLDER })).resolves.toBeDefined()
+  }, 120_000)
+
+  it('values the holder position', async () => {
+    const [position] = await getVaultPositions([testCase.receiptId], testCase.key, options())
+    expect(position!.shares).toBeGreaterThan(0n)
+    expect(position!.balance).toBeGreaterThan(0n)
+  }, 120_000)
+
+  it('full exit burns the whole position and reports what it returns', async () => {
+    const [position] = await getVaultPositions([testCase.receiptId], testCase.key, options())
+    const preview = await previewWithdraw(
+      { vault: testCase.key, receiptId: testCase.receiptId, amount: MAX_U64, sender: HOLDER },
+      options()
+    )
+
+    // fromDefault clamps the amount to the holder's maximum and the contract clamps the
+    // burn to what they actually hold, so a full exit never over-burns.
+    expect(preview.sharesBurned).toBe(position!.shares)
+    expect(preview.maxShares).toBeGreaterThan(preview.sharesBurned)
+
+    // The returned amount is authoritative and is at most the valued balance — the
+    // virtual-share offset means a full exit leaves a little behind.
+    expect(preview.amountOut).toBeDefined()
+    expect(preview.amountOut!).toBeGreaterThan(0n)
+    expect(preview.amountOut!).toBeLessThanOrEqual(position!.balance)
+  }, 120_000)
+
+  it('reward claim simulates through harvest', async () => {
+    const amount = await previewClaimReward(
+      {
+        vault: testCase.key,
+        receiptId: testCase.receiptId,
+        rewardCoinType: CERT,
+        sender: HOLDER
+      },
+      options()
+    )
+    // A vault with no rules pays zero; one with an active rule may pay more.
+    expect(amount).toBeGreaterThanOrEqual(0n)
+  }, 120_000)
+})
+
+describe.skipIf(!runLiveTests)('abort classification against live state', () => {
+  it('reports an unknown receipt as a user error, not an outage', async () => {
+    try {
+      await previewWithdraw(
+        {
+          vault: 'SUI_PRIME',
+          receiptId: `0x${'e'.repeat(64)}`,
+          amount: 1_000n,
+          sender: HOLDER
+        },
+        options()
+      )
+      expect.unreachable('withdrawal against a nonexistent receipt should fail')
+    } catch (error) {
+      const decoded = parseVaultError(error)
+      if (decoded) {
+        expect(decoded.kind).not.toBe('outage')
+      }
+    }
+  }, 120_000)
+})
+
+describe.skipIf(!runLiveTests)('gas estimation', () => {
+  it('reports a plausible net cost for a deposit block', async () => {
+    const tx = await buildDepositTx(
+      { vault: 'SUI_PRIME', amount: 100_000_000n, sender: HOLDER, position: 'new' },
+      options()
+    )
+    const gas = await estimateGas(tx, { ...options(), sender: HOLDER })
+
+    expect(gas.computationCost).toBeGreaterThan(0n)
+    expect(gas.netCost).toBe(gas.computationCost + gas.storageCost - gas.storageRebate)
+    // A 6-command block on mainnet lands well under 0.1 SUI; anything above that means
+    // the estimate is being read from the wrong field.
+    expect(gas.netCost).toBeLessThan(100_000_000n)
+  }, 120_000)
+})

--- a/packages/vault/tsconfig.json
+++ b/packages/vault/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../config/tsconfig.base.json",
+  "include": ["src"]
+}

--- a/packages/vault/tsconfig.type-tests.json
+++ b/packages/vault/tsconfig.type-tests.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "declarationMap": false,
+    "noEmit": true,
+    "noUncheckedIndexedAccess": true,
+    "baseUrl": ".",
+    "paths": {
+      "@naviprotocol/vault": ["dist/index.d.ts"]
+    }
+  },
+  "include": ["tests/type-compat/**/*.ts"]
+}

--- a/packages/vault/typedoc.json
+++ b/packages/vault/typedoc.json
@@ -1,0 +1,6 @@
+{
+  "entryPoints": ["src"],
+  "excludeInternal": true,
+  "excludePrivate": true,
+  "intentionallyNotExported": []
+}

--- a/packages/vault/vite.config.js
+++ b/packages/vault/vite.config.js
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vite'
+
+import baseConfig from '../../config/vite.lib.config'
+
+export default defineConfig(baseConfig)

--- a/packages/vault/vite.config.unit.js
+++ b/packages/vault/vite.config.unit.js
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite'
+
+import baseConfig from '../../config/vite.lib.config'
+
+const PWD = process.env.PWD
+
+export default defineConfig({
+  ...baseConfig,
+  test: {
+    ...(baseConfig.test || {}),
+    testTimeout: 30000,
+    environment: 'node',
+    include: [`${PWD}/**/*.{spec,test}.{ts,tsx}`]
+  }
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -347,6 +347,34 @@ importers:
         specifier: 3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.7.5)(jsdom@27.0.0(bufferutil@4.0.9)(postcss@8.5.6)(utf-8-validate@5.0.10))(lightningcss@1.30.1)
 
+  packages/vault:
+    dependencies:
+      '@naviprotocol/lending':
+        specifier: workspace:^
+        version: link:../lending
+      bignumber.js:
+        specifier: 9.1.2
+        version: 9.1.2
+    devDependencies:
+      '@mysten/sui':
+        specifier: 2.20.2
+        version: 2.20.2(typescript@5.8.3)
+      '@types/node':
+        specifier: 22.7.5
+        version: 22.7.5
+      tsconfig-paths:
+        specifier: 4.2.0
+        version: 4.2.0
+      tsx:
+        specifier: 4.19.2
+        version: 4.19.2
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.7.5)(jsdom@27.0.0(bufferutil@4.0.9)(postcss@8.5.6)(utf-8-validate@5.0.10))(lightningcss@1.30.1)
+
   packages/wallet-client:
     dependencies:
       '@naviprotocol/astros-aggregator-sdk':
@@ -1253,6 +1281,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.23.1':
+    resolution: {integrity: sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.25.10':
     resolution: {integrity: sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==}
     engines: {node: '>=18'}
@@ -1268,6 +1302,12 @@ packages:
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.23.1':
+    resolution: {integrity: sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -1289,6 +1329,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.23.1':
+    resolution: {integrity: sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-arm@0.25.10':
     resolution: {integrity: sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==}
     engines: {node: '>=18'}
@@ -1304,6 +1350,12 @@ packages:
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.23.1':
+    resolution: {integrity: sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -1325,6 +1377,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.23.1':
+    resolution: {integrity: sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.25.10':
     resolution: {integrity: sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==}
     engines: {node: '>=18'}
@@ -1340,6 +1398,12 @@ packages:
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.23.1':
+    resolution: {integrity: sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -1361,6 +1425,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.23.1':
+    resolution: {integrity: sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.25.10':
     resolution: {integrity: sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==}
     engines: {node: '>=18'}
@@ -1376,6 +1446,12 @@ packages:
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.23.1':
+    resolution: {integrity: sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -1397,6 +1473,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.23.1':
+    resolution: {integrity: sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.25.10':
     resolution: {integrity: sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==}
     engines: {node: '>=18'}
@@ -1412,6 +1494,12 @@ packages:
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.23.1':
+    resolution: {integrity: sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -1433,6 +1521,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.23.1':
+    resolution: {integrity: sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.25.10':
     resolution: {integrity: sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==}
     engines: {node: '>=18'}
@@ -1448,6 +1542,12 @@ packages:
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.23.1':
+    resolution: {integrity: sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -1469,6 +1569,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.23.1':
+    resolution: {integrity: sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.25.10':
     resolution: {integrity: sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==}
     engines: {node: '>=18'}
@@ -1484,6 +1590,12 @@ packages:
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.23.1':
+    resolution: {integrity: sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -1505,6 +1617,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.23.1':
+    resolution: {integrity: sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.25.10':
     resolution: {integrity: sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==}
     engines: {node: '>=18'}
@@ -1523,6 +1641,12 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.23.1':
+    resolution: {integrity: sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.10':
     resolution: {integrity: sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==}
     engines: {node: '>=18'}
@@ -1538,6 +1662,12 @@ packages:
   '@esbuild/linux-x64@0.21.5':
     resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.23.1':
+    resolution: {integrity: sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
@@ -1571,6 +1701,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.23.1':
+    resolution: {integrity: sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.25.10':
     resolution: {integrity: sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==}
     engines: {node: '>=18'}
@@ -1582,6 +1718,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.23.1':
+    resolution: {integrity: sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
 
   '@esbuild/openbsd-arm64@0.25.10':
     resolution: {integrity: sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==}
@@ -1598,6 +1740,12 @@ packages:
   '@esbuild/openbsd-x64@0.21.5':
     resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.23.1':
+    resolution: {integrity: sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
@@ -1631,6 +1779,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.23.1':
+    resolution: {integrity: sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.25.10':
     resolution: {integrity: sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==}
     engines: {node: '>=18'}
@@ -1646,6 +1800,12 @@ packages:
   '@esbuild/win32-arm64@0.21.5':
     resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.23.1':
+    resolution: {integrity: sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
@@ -1667,6 +1827,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.23.1':
+    resolution: {integrity: sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.25.10':
     resolution: {integrity: sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==}
     engines: {node: '>=18'}
@@ -1682,6 +1848,12 @@ packages:
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.23.1':
+    resolution: {integrity: sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -4022,6 +4194,11 @@ packages:
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.23.1:
+    resolution: {integrity: sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==}
+    engines: {node: '>=18'}
     hasBin: true
 
   esbuild@0.25.10:
@@ -6430,6 +6607,11 @@ packages:
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
 
+  tsx@4.19.2:
+    resolution: {integrity: sha512-pOUl6Vo2LUq/bSa8S5q7b91cgNSjctn9ugq/+Mvow99qW6x/UZYwzxy/3NmqoT66eHYfCVvFvACC58UBPFf28g==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
@@ -8071,6 +8253,9 @@ snapshots:
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
+  '@esbuild/aix-ppc64@0.23.1':
+    optional: true
+
   '@esbuild/aix-ppc64@0.25.10':
     optional: true
 
@@ -8078,6 +8263,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.23.1':
     optional: true
 
   '@esbuild/android-arm64@0.25.10':
@@ -8089,6 +8277,9 @@ snapshots:
   '@esbuild/android-arm@0.21.5':
     optional: true
 
+  '@esbuild/android-arm@0.23.1':
+    optional: true
+
   '@esbuild/android-arm@0.25.10':
     optional: true
 
@@ -8096,6 +8287,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.23.1':
     optional: true
 
   '@esbuild/android-x64@0.25.10':
@@ -8107,6 +8301,9 @@ snapshots:
   '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
+  '@esbuild/darwin-arm64@0.23.1':
+    optional: true
+
   '@esbuild/darwin-arm64@0.25.10':
     optional: true
 
@@ -8114,6 +8311,9 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.23.1':
     optional: true
 
   '@esbuild/darwin-x64@0.25.10':
@@ -8125,6 +8325,9 @@ snapshots:
   '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.23.1':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.25.10':
     optional: true
 
@@ -8132,6 +8335,9 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.23.1':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.10':
@@ -8143,6 +8349,9 @@ snapshots:
   '@esbuild/linux-arm64@0.21.5':
     optional: true
 
+  '@esbuild/linux-arm64@0.23.1':
+    optional: true
+
   '@esbuild/linux-arm64@0.25.10':
     optional: true
 
@@ -8150,6 +8359,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.23.1':
     optional: true
 
   '@esbuild/linux-arm@0.25.10':
@@ -8161,6 +8373,9 @@ snapshots:
   '@esbuild/linux-ia32@0.21.5':
     optional: true
 
+  '@esbuild/linux-ia32@0.23.1':
+    optional: true
+
   '@esbuild/linux-ia32@0.25.10':
     optional: true
 
@@ -8168,6 +8383,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.23.1':
     optional: true
 
   '@esbuild/linux-loong64@0.25.10':
@@ -8179,6 +8397,9 @@ snapshots:
   '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
+  '@esbuild/linux-mips64el@0.23.1':
+    optional: true
+
   '@esbuild/linux-mips64el@0.25.10':
     optional: true
 
@@ -8186,6 +8407,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.23.1':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.10':
@@ -8197,6 +8421,9 @@ snapshots:
   '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
+  '@esbuild/linux-riscv64@0.23.1':
+    optional: true
+
   '@esbuild/linux-riscv64@0.25.10':
     optional: true
 
@@ -8206,6 +8433,9 @@ snapshots:
   '@esbuild/linux-s390x@0.21.5':
     optional: true
 
+  '@esbuild/linux-s390x@0.23.1':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.10':
     optional: true
 
@@ -8213,6 +8443,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.23.1':
     optional: true
 
   '@esbuild/linux-x64@0.25.10':
@@ -8230,10 +8463,16 @@ snapshots:
   '@esbuild/netbsd-x64@0.21.5':
     optional: true
 
+  '@esbuild/netbsd-x64@0.23.1':
+    optional: true
+
   '@esbuild/netbsd-x64@0.25.10':
     optional: true
 
   '@esbuild/netbsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.23.1':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.10':
@@ -8243,6 +8482,9 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.23.1':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.10':
@@ -8260,6 +8502,9 @@ snapshots:
   '@esbuild/sunos-x64@0.21.5':
     optional: true
 
+  '@esbuild/sunos-x64@0.23.1':
+    optional: true
+
   '@esbuild/sunos-x64@0.25.10':
     optional: true
 
@@ -8267,6 +8512,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.23.1':
     optional: true
 
   '@esbuild/win32-arm64@0.25.10':
@@ -8278,6 +8526,9 @@ snapshots:
   '@esbuild/win32-ia32@0.21.5':
     optional: true
 
+  '@esbuild/win32-ia32@0.23.1':
+    optional: true
+
   '@esbuild/win32-ia32@0.25.10':
     optional: true
 
@@ -8285,6 +8536,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.23.1':
     optional: true
 
   '@esbuild/win32-x64@0.25.10':
@@ -10943,6 +11197,33 @@ snapshots:
       '@esbuild/win32-arm64': 0.21.5
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
+
+  esbuild@0.23.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.23.1
+      '@esbuild/android-arm': 0.23.1
+      '@esbuild/android-arm64': 0.23.1
+      '@esbuild/android-x64': 0.23.1
+      '@esbuild/darwin-arm64': 0.23.1
+      '@esbuild/darwin-x64': 0.23.1
+      '@esbuild/freebsd-arm64': 0.23.1
+      '@esbuild/freebsd-x64': 0.23.1
+      '@esbuild/linux-arm': 0.23.1
+      '@esbuild/linux-arm64': 0.23.1
+      '@esbuild/linux-ia32': 0.23.1
+      '@esbuild/linux-loong64': 0.23.1
+      '@esbuild/linux-mips64el': 0.23.1
+      '@esbuild/linux-ppc64': 0.23.1
+      '@esbuild/linux-riscv64': 0.23.1
+      '@esbuild/linux-s390x': 0.23.1
+      '@esbuild/linux-x64': 0.23.1
+      '@esbuild/netbsd-x64': 0.23.1
+      '@esbuild/openbsd-arm64': 0.23.1
+      '@esbuild/openbsd-x64': 0.23.1
+      '@esbuild/sunos-x64': 0.23.1
+      '@esbuild/win32-arm64': 0.23.1
+      '@esbuild/win32-ia32': 0.23.1
+      '@esbuild/win32-x64': 0.23.1
 
   esbuild@0.25.10:
     optionalDependencies:
@@ -13961,6 +14242,13 @@ snapshots:
     dependencies:
       tslib: 1.14.1
       typescript: 5.8.3
+
+  tsx@4.19.2:
+    dependencies:
+      esbuild: 0.23.1
+      get-tsconfig: 4.10.1
+    optionalDependencies:
+      fsevents: 2.3.3
 
   tsx@4.21.0:
     dependencies:


### PR DESCRIPTION
## Description

Adds `@naviprotocol/vault`, an SDK for NAVI's lending vaults — deposit, withdraw, reward claims, and simulation-based pricing.

Also exports `devInspectTransaction` from `@naviprotocol/lending` so the vault package can reuse its v2 Core simulation transport instead of duplicating it.

## Test plan

- 126 tests, 30 of which run against mainnet (`NAVI_LIVE_TESTS=1`)
- Read paths verified against all four live vaults
- Deposit and full exit executed on mainnet:
  - [deposit, SUI High Yield](https://suiscan.xyz/mainnet/tx/HhcGBwRHPV7oMYzsHJUgKuXFMQdQTE24Axd72C22WERe)
  - [full exit, SUI Prime](https://suiscan.xyz/mainnet/tx/AEAw8XUJbZoFsX3kwQcuXor6sWMfw7GRLPXSUFyYZvUa)
- Reward claim is simulated only, not yet executed on chain

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New on-chain transaction surface (deposits/withdrawals with multi-call prologues and oracle delegation) and a public lending export; mistakes in PTB ordering or error classification could cause failed txs or bad UX, though coverage includes mainnet simulation and documented mainnet deposit/exit runs.
> 
> **Overview**
> Introduces **`@naviprotocol/vault`**, a new SDK for NAVI single-asset yield vaults on Sui: on-chain layout discovery, receipt lookup, simulation-based quotes/previews, and PTB/`build*Tx` helpers for deposit, withdraw, full exit, and reward claims. Deposits and withdrawals automatically prepend the contract’s **freshness prologue** (per-market `sync_market_balance` + active-rule `collect_reward`); withdrawals also prepend an **oracle price update** via `@naviprotocol/lending` so oracle entrypoint changes come from config, not a vault release.
> 
> Adds **`parseVaultError`** / **`isProtocolOutage`** so vault, lending (e.g. 1400/1506), and oracle (1502) aborts are classified correctly for integrators. Ships a mainnet config snapshot, README, unit/live tests, optional **`roundtrip`** mainnet script, and monorepo wiring (tsconfig path, SDK v2 boundary check, changeset).
> 
> **`@naviprotocol/lending`** (patch): publicly exports **`devInspectTransaction`** so vault (and others) can simulate read-only blocks on the same v2 Core transport.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35375d350f409111661c0b83567454a71f6885e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->