### PR TITLE
chore(release): update lending and wallet-client to version 2.0.9

### DIFF
--- a/packages/lending/CHANGELOG.md
+++ b/packages/lending/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @naviprotocol/lending
 
+## 2.0.9
+
+### Patch Changes
+
+- new lending market: sui-eco, sui-usdc, wbtc-usdc, xbtc-usdc, vsui-usdc, vsui-sui, hasui-sui
+
 ## 2.0.8
 
 ### Patch Changes

--- a/packages/lending/package.json
+++ b/packages/lending/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@naviprotocol/lending",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "NAVI Lending SDK",
   "license": "MIT",
   "type": "module",

--- a/packages/lending/src/market.ts
+++ b/packages/lending/src/market.ts
@@ -33,6 +33,36 @@ export const MARKETS = {
     id: 3,
     key: 'sui-eco',
     name: 'Sui Eco Market'
+  },
+  "sui-usdc": {
+    id: 4,
+    key: "sui-usdc",
+    name: "SUI / USDC Market"
+  },
+  "wbtc-usdc": {
+    id: 5,
+    key: "wbtc-usdc",
+    name: "WBTC / USDC Market"
+  },
+  "xbtc-usdc": {
+    id: 6,
+    key: "xbtc-usdc",
+    name: "xBTC / USDC Market"
+  },
+  "vsui-usdc": {
+    id: 7,
+    key: "vsui-usdc",
+    name: "vSUI / USDC Market"
+  },
+  "vsui-sui": {
+    id: 8,
+    key: "vsui-sui",
+    name: "vSUI / SUI Market"
+  },
+  "hasui-sui": {
+    id: 9,
+    key: "hasui-sui",
+    name: "haSUI / SUI Market"
   }
 }
 

--- a/packages/wallet-client/CHANGELOG.md
+++ b/packages/wallet-client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @naviprotocol/wallet-client
 
+## 2.0.9
+
+### Patch Changes
+
+- Updated dependencies
+  - @naviprotocol/lending@2.0.9
+
 ## 2.0.8
 
 ### Patch Changes

--- a/packages/wallet-client/package.json
+++ b/packages/wallet-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@naviprotocol/wallet-client",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "NAVI Wallet Client",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Description

Describe the changes or additions included in this PR.

## Test plan

How did you test the new or updated feature?

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive market metadata and version/changelog updates only; no changes to lending transaction or account logic.
> 
> **Overview**
> **Release 2.0.9** for `@naviprotocol/lending` and `@naviprotocol/wallet-client`, with wallet-client depending on lending `@2.0.9`.
> 
> The lending SDK **`MARKETS`** registry in `market.ts` gains six pair markets (ids 4–9): `sui-usdc`, `wbtc-usdc`, `xbtc-usdc`, `vsui-usdc`, `vsui-sui`, and `hasui-sui`, so `getMarketConfig` / `getMarkets` can resolve those keys. Changelogs record the new markets for this patch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81378488020e2fd6a5261e7e865490b0c672afe6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->